### PR TITLE
refactor: Deprecate harrytmthy-dev namespace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Make @harrytmthy-dev the code owner of all files
-* @harrytmthy-dev
+# Make @harrytmthy the code owner of all files
+* @harrytmthy

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: harrytmthy-dev
+github: harrytmthy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,63 +5,63 @@ All notable changes to this project will be documented in this file.
 ## [1.1.0] - 2025-06-11
 
 ### Added
-- **SafeBoxStateManager**: A centralized lifecycle controller that manages `STARTING`, `WRITING`, `IDLE`, and `CLOSED` states per SafeBox instance. It tracks concurrent edits and ensures deterministic closure via `closeWhenIdle()`. ([#17](https://github.com/harrytmthy-dev/safebox/issues/17))
-- **SafeBoxGlobalStateObserver**: Observes SafeBox state transitions globally by file name. Useful for debugging or monitoring multiple files. ([#12](https://github.com/harrytmthy-dev/safebox/issues/12))
+- **SafeBoxStateManager**: A centralized lifecycle controller that manages `STARTING`, `WRITING`, `IDLE`, and `CLOSED` states per SafeBox instance. It tracks concurrent edits and ensures deterministic closure via `closeWhenIdle()`. ([#17](https://github.com/harrytmthy/safebox/issues/17))
+- **SafeBoxGlobalStateObserver**: Observes SafeBox state transitions globally by file name. Useful for debugging or monitoring multiple files. ([#12](https://github.com/harrytmthy/safebox/issues/12))
 - **SafeBoxStateListener**: Per-instance listener for tracking lifecycle changes.
-- **SafeBoxBlobFileRegistry**: Prevents multiple SafeBox instances from accessing the same file simultaneously, resolving potential file channel conflicts. ([#10](https://github.com/harrytmthy-dev/safebox/issues/10))
-- **SafeBoxExecutor**: Internal single-thread executor that supports background crypto operations and is publicly reusable for extensions. ([#30](https://github.com/harrytmthy-dev/safebox/pull/30))
-- **CipherPool**: A coroutine-friendly pool for reusing `Cipher` instances across threads. Helps prevent race conditions and improves crypto throughput. ([#25](https://github.com/harrytmthy-dev/safebox/issues/25))
-- **SafeBoxMigrationHelper**: Migrate from `EncryptedSharedPreferences` using standard `SharedPreferences` API. ([#13](https://github.com/harrytmthy-dev/safebox/pull/13))
+- **SafeBoxBlobFileRegistry**: Prevents multiple SafeBox instances from accessing the same file simultaneously, resolving potential file channel conflicts. ([#10](https://github.com/harrytmthy/safebox/issues/10))
+- **SafeBoxExecutor**: Internal single-thread executor that supports background crypto operations and is publicly reusable for extensions. ([#30](https://github.com/harrytmthy/safebox/pull/30))
+- **CipherPool**: A coroutine-friendly pool for reusing `Cipher` instances across threads. Helps prevent race conditions and improves crypto throughput. ([#25](https://github.com/harrytmthy/safebox/issues/25))
+- **SafeBoxMigrationHelper**: Migrate from `EncryptedSharedPreferences` using standard `SharedPreferences` API. ([#13](https://github.com/harrytmthy/safebox/pull/13))
 
 ### Changed
-- **ChaCha20CipherProvider**: Now backed by `CipherPool` for thread-safe encryption and decryption. ([#25](https://github.com/harrytmthy-dev/safebox/issues/25))
-- **SafeSecretKey**: Rewritten for concurrency using short-lived heap caches and reduced synchronized scope. ([#26](https://github.com/harrytmthy-dev/safebox/issues/26))
-- **SecureRandomKeyProvider**: Improved concurrency behavior when retrieving or decrypting keys. ([#26](https://github.com/harrytmthy-dev/safebox/issues/26))
-- **BouncyCastleProvider**: Lazy-injected only when ChaCha20 isn't available, preserving host app provider configs. ([#1](https://github.com/harrytmthy-dev/safebox/issues/1))
-- **compileSdkVersion** bumped to `36`. ([#2](https://github.com/harrytmthy-dev/safebox/issues/2))
+- **ChaCha20CipherProvider**: Now backed by `CipherPool` for thread-safe encryption and decryption. ([#25](https://github.com/harrytmthy/safebox/issues/25))
+- **SafeSecretKey**: Rewritten for concurrency using short-lived heap caches and reduced synchronized scope. ([#26](https://github.com/harrytmthy/safebox/issues/26))
+- **SecureRandomKeyProvider**: Improved concurrency behavior when retrieving or decrypting keys. ([#26](https://github.com/harrytmthy/safebox/issues/26))
+- **BouncyCastleProvider**: Lazy-injected only when ChaCha20 isn't available, preserving host app provider configs. ([#1](https://github.com/harrytmthy/safebox/issues/1))
+- **compileSdkVersion** bumped to `36`. ([#2](https://github.com/harrytmthy/safebox/issues/2))
 
 ### Security
-- **XOR-based key masking**: `SafeSecretKey` is now masked in memory using a SHA-256-derived mask. Prevents native memory inspection of raw DEK. ([#23](https://github.com/harrytmthy-dev/safebox/issues/23))
-- **On-demand cipher creation**: `AesGcmCipherProvider` no longer holds long-lived `Cipher` instances. ([#28](https://github.com/harrytmthy-dev/safebox/issues/28))
+- **XOR-based key masking**: `SafeSecretKey` is now masked in memory using a SHA-256-derived mask. Prevents native memory inspection of raw DEK. ([#23](https://github.com/harrytmthy/safebox/issues/23))
+- **On-demand cipher creation**: `AesGcmCipherProvider` no longer holds long-lived `Cipher` instances. ([#28](https://github.com/harrytmthy/safebox/issues/28))
 
 ### Docs
-- Added **v1.1.0 benchmark results** showing faster performance across `get()`, `put()`, and `commit()` operations. ([#35](https://github.com/harrytmthy-dev/safebox/issues/35))
-- Enabled [**GitHub Sponsors**](https://github.com/sponsors/harrytmthy-dev) with the new `Support SafeBox` section. ([#37](https://github.com/harrytmthy-dev/safebox/issues/37))
-- Added project metadata badges: Build, License, and Version. ([#39](https://github.com/harrytmthy-dev/safebox/issues/39))
+- Added **v1.1.0 benchmark results** showing faster performance across `get()`, `put()`, and `commit()` operations. ([#35](https://github.com/harrytmthy/safebox/issues/35))
+- Enabled [**GitHub Sponsors**](https://github.com/sponsors/harrytmthy) with the new `Support SafeBox` section. ([#37](https://github.com/harrytmthy/safebox/issues/37))
+- Added project metadata badges: Build, License, and Version. ([#39](https://github.com/harrytmthy/safebox/issues/39))
 
 ## [1.1.0-rc01] - 2025-06-09
 
 ### Added
-- **CipherPool**: A coroutine-friendly, thread-safe pool for reusing `Cipher` instances across threads, backed by a load-factor-based expansion strategy. Prevents cryptographic race conditions in read-heavy workloads. ([#25](https://github.com/harrytmthy-dev/safebox/issues/25))
-- **SafeBoxExecutor**: Internal singleton executor to support background concurrency operations like CipherPool scaling. Publicly reusable for custom extensions. ([#30](https://github.com/harrytmthy-dev/safebox/pull/30))
+- **CipherPool**: A coroutine-friendly, thread-safe pool for reusing `Cipher` instances across threads, backed by a load-factor-based expansion strategy. Prevents cryptographic race conditions in read-heavy workloads. ([#25](https://github.com/harrytmthy/safebox/issues/25))
+- **SafeBoxExecutor**: Internal singleton executor to support background concurrency operations like CipherPool scaling. Publicly reusable for custom extensions. ([#30](https://github.com/harrytmthy/safebox/pull/30))
 
 ### Changed
-- **ChaCha20CipherProvider** now uses `CipherPool` for safe concurrent encryption/decryption. ([#25](https://github.com/harrytmthy-dev/safebox/issues/25))
-- **SafeSecretKey**: Now supports concurrent access by reducing synchronized scope, caching the unmasked key in a short-lived atomic heap reference. ([#26](https://github.com/harrytmthy-dev/safebox/issues/26))
-- **SecureRandomKeyProvider**: Key caching and unmasking now support concurrent access patterns without blocking parallel threads. ([#26](https://github.com/harrytmthy-dev/safebox/issues/26))
-- **BouncyCastle provider initialization** is now safer and more flexible: `CipherPool` lazily injects the provider only when ChaCha20 is not available, reducing the risk of overwriting external configurations. ([#1](https://github.com/harrytmthy-dev/safebox/issues/1))
-- **compileSdk bumped to 36**: Ensure SafeBox stays forward-compatible with the latest Android APIs. ([#2](https://github.com/harrytmthy-dev/safebox/issues/2))
+- **ChaCha20CipherProvider** now uses `CipherPool` for safe concurrent encryption/decryption. ([#25](https://github.com/harrytmthy/safebox/issues/25))
+- **SafeSecretKey**: Now supports concurrent access by reducing synchronized scope, caching the unmasked key in a short-lived atomic heap reference. ([#26](https://github.com/harrytmthy/safebox/issues/26))
+- **SecureRandomKeyProvider**: Key caching and unmasking now support concurrent access patterns without blocking parallel threads. ([#26](https://github.com/harrytmthy/safebox/issues/26))
+- **BouncyCastle provider initialization** is now safer and more flexible: `CipherPool` lazily injects the provider only when ChaCha20 is not available, reducing the risk of overwriting external configurations. ([#1](https://github.com/harrytmthy/safebox/issues/1))
+- **compileSdk bumped to 36**: Ensure SafeBox stays forward-compatible with the latest Android APIs. ([#2](https://github.com/harrytmthy/safebox/issues/2))
 
 ### Security
-- **XOR-based in-memory masking** added to `SafeSecretKey`, preventing runtime memory inspection of the raw DEK. The key is stored in masked form using a SHA-256 hash of the encrypted DEK as its mask. ([#23](https://github.com/harrytmthy-dev/safebox/issues/23))
-- **On-demand Cipher creation** for `AesGcmCipherProvider`, eliminating long-lived `Cipher` references that may retain sensitive key material. ([#28](https://github.com/harrytmthy-dev/safebox/issues/28))
+- **XOR-based in-memory masking** added to `SafeSecretKey`, preventing runtime memory inspection of the raw DEK. The key is stored in masked form using a SHA-256 hash of the encrypted DEK as its mask. ([#23](https://github.com/harrytmthy/safebox/issues/23))
+- **On-demand Cipher creation** for `AesGcmCipherProvider`, eliminating long-lived `Cipher` references that may retain sensitive key material. ([#28](https://github.com/harrytmthy/safebox/issues/28))
 
 ## [1.1.0-beta01] - 2025-06-04
 
 ### Added
-- **SafeBoxStateManager** is now the sole authority over lifecycle states (`STARTING`, `WRITING`, `IDLE`, `CLOSED`). It tracks concurrent edits, coordinates safe apply/commit transitions, and guarantees deterministic closure in `closeWhenIdle()`. ([#17](https://github.com/harrytmthy-dev/safebox/issues/17))
-- **Write guard after closure:** Once `SafeBox` transitions to `CLOSED`, all subsequent write operations (`apply()` or `commit()`) are safely blocked. Prevents late `WRITING` emissions and ensures lifecycle integrity. ([#19](https://github.com/harrytmthy-dev/safebox/issues/19))
+- **SafeBoxStateManager** is now the sole authority over lifecycle states (`STARTING`, `WRITING`, `IDLE`, `CLOSED`). It tracks concurrent edits, coordinates safe apply/commit transitions, and guarantees deterministic closure in `closeWhenIdle()`. ([#17](https://github.com/harrytmthy/safebox/issues/17))
+- **Write guard after closure:** Once `SafeBox` transitions to `CLOSED`, all subsequent write operations (`apply()` or `commit()`) are safely blocked. Prevents late `WRITING` emissions and ensures lifecycle integrity. ([#19](https://github.com/harrytmthy/safebox/issues/19))
 
 ### Fixed
-- GPG signing and secret injection issues in the Maven publish pipeline, resolving deployment failure from alpha02. ([PR #16](https://github.com/harrytmthy-dev/safebox/pull/16))
+- GPG signing and secret injection issues in the Maven publish pipeline, resolving deployment failure from alpha02. ([PR #16](https://github.com/harrytmthy/safebox/pull/16))
 
 ## [1.1.0-alpha02] - 2025-06-02
 
 ### Added
-- **SafeBoxBlobFileRegistry** prevents multiple `SafeBox` instances from accessing the same blob file. This enforces a **single-instance-per-file** constraint internally, resolving the risk documented in [#3](https://github.com/harrytmthy-dev/safebox/issues/3). ([#10](https://github.com/harrytmthy-dev/safebox/issues/10))
-- **SafeBoxStateListener** for tracking `SafeBox` lifecycle states (`STARTING`, `IDLE`, `WRITING`, `CLOSED`). It can be attached per-instance via `SafeBox.create(...)` or registered globally via `SafeBoxGlobalStateObserver`. ([#12](https://github.com/harrytmthy-dev/safebox/issues/12))
-- **SafeBoxGlobalStateObserver** tracks `SafeBox` state transitions by file name, with support for multiple listeners. ([#12](https://github.com/harrytmthy-dev/safebox/issues/12))
-- `SafeBox#closeWhenIdle()` defers closure until all pending writes are complete, preventing premature teardown in async environments. ([#12](https://github.com/harrytmthy-dev/safebox/issues/12))
+- **SafeBoxBlobFileRegistry** prevents multiple `SafeBox` instances from accessing the same blob file. This enforces a **single-instance-per-file** constraint internally, resolving the risk documented in [#3](https://github.com/harrytmthy/safebox/issues/3). ([#10](https://github.com/harrytmthy/safebox/issues/10))
+- **SafeBoxStateListener** for tracking `SafeBox` lifecycle states (`STARTING`, `IDLE`, `WRITING`, `CLOSED`). It can be attached per-instance via `SafeBox.create(...)` or registered globally via `SafeBoxGlobalStateObserver`. ([#12](https://github.com/harrytmthy/safebox/issues/12))
+- **SafeBoxGlobalStateObserver** tracks `SafeBox` state transitions by file name, with support for multiple listeners. ([#12](https://github.com/harrytmthy/safebox/issues/12))
+- `SafeBox#closeWhenIdle()` defers closure until all pending writes are complete, preventing premature teardown in async environments. ([#12](https://github.com/harrytmthy/safebox/issues/12))
 
 ### Behavior Changes
 - Calling `SafeBox.create(...)` before closing the existing instance with the same file name now throws `IllegalStateException`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing! SafeBox welcomes improvements, bug fixes
 ## Local Setup
 
 ```bash
-git clone https://github.com/harrytmthy-dev/safebox.git
+git clone https://github.com/harrytmthy/safebox.git
 ```
 
 ### Update pre-hook path
@@ -53,7 +53,7 @@ CI runs instrumented tests automatically on:
 
 ## Contributor Etiquette
 
-- Discuss major changes or feature proposals first via [Issues](https://github.com/harrytmthy-dev/safebox/issues).
+- Discuss major changes or feature proposals first via [Issues](https://github.com/harrytmthy/safebox/issues).
 - Be respectful during reviews! We're building something safe and friendly.
 - If anything is unclear, don't hesitate to ask!
 
@@ -79,7 +79,7 @@ Update the following files in the same commit:
   Update the version in the `Installation` section:
 
   ```kotlin
-  implementation("io.github.harrytmthy-dev:safebox:1.2.0-alpha01")
+  implementation("io.github.harrytmthy:safebox:1.2.0-alpha01")
   ```
   
 - **`:safebox/build.gradle.kts`**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SafeBox
 
-[![Build](https://img.shields.io/github/actions/workflow/status/harrytmthy-dev/safebox/ci.yml?branch=main&label=build&logo=githubactions&logoColor=white&style=flat-square)](https://github.com/harrytmthy-dev/safebox/actions)
-[![License](https://img.shields.io/github/license/harrytmthy-dev/safebox?label=license&color=blue&style=flat-square)](https://github.com/harrytmthy-dev/safebox/blob/main/LICENSE)
-[![Release](https://img.shields.io/github/v/release/harrytmthy-dev/safebox?include_prereleases&label=release&color=orange&style=flat-square)](https://github.com/harrytmthy-dev/safebox/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/harrytmthy/safebox/ci.yml?branch=main&label=build&logo=githubactions&logoColor=white&style=flat-square)](https://github.com/harrytmthy/safebox/actions)
+[![License](https://img.shields.io/github/license/harrytmthy/safebox?label=license&color=blue&style=flat-square)](https://github.com/harrytmthy/safebox/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/harrytmthy/safebox?include_prereleases&label=release&color=orange&style=flat-square)](https://github.com/harrytmthy/safebox/releases)
 
 A secure, blazing-fast alternative to `EncryptedSharedPreferences`, designed for Android projects which demand both **speed** and **security**.
 
@@ -53,9 +53,15 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy-dev:safebox:1.1.0")
+    implementation("io.github.harrytmthy:safebox:1.1.0")
 }
 ```
+
+### ⚠️ Heads up
+
+The `io.github.harrytmthy-dev` namespace is now **deprecated**. Starting from `v1.2.0-alpha01`, SafeBox will be published under the canonical Maven group `io.github.harrytmthy`.
+
+Please update your dependencies accordingly.
 
 ## Basic Usage
 
@@ -251,7 +257,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, formatting, testing, and PR gu
 
 If SafeBox helped secure your app or saved your time, consider sponsoring to support future improvements and maintenance!
 
-[![Sponsor](https://img.shields.io/badge/sponsor-%F0%9F%92%96-blueviolet?style=flat-square)](https://github.com/sponsors/harrytmthy-dev)
+[![Sponsor](https://img.shields.io/badge/sponsor-%F0%9F%92%96-blueviolet?style=flat-square)](https://github.com/sponsors/harrytmthy)
 
 ## License
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -60,6 +60,6 @@ SafeBoxMigrationHelper.migrate(from = encryptedPrefs, to = safeBox)
 
 - SafeBox is open-source and MIT licensed
 - Fully tested, memory-safe, and designed for offline-first applications
-- Already published to [Maven Central](https://central.sonatype.com/artifact/io.github.harrytmthy-dev/safebox)
+- Already published to [Maven Central](https://central.sonatype.com/artifact/io.github.harrytmthy/safebox)
 
-Looking to contribute? Found an edge case? Let us know or [open an issue](https://github.com/harrytmthy-dev/safebox/issues).
+Looking to contribute? Found an edge case? Let us know or [open an issue](https://github.com/harrytmthy/safebox/issues).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
 protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
-safebox = { group = "io.github.harrytmthy-dev", name = "safebox", version.ref = "safebox" }
+safebox = { group = "io.github.harrytmthy", name = "safebox", version.ref = "safebox" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
 [plugins]

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-group = "io.github.harrytmthy-dev"
+group = "io.github.harrytmthy"
 version = "1.1.0"
 
 android {
@@ -102,15 +102,15 @@ mavenPublishing {
 
         developers {
             developer {
-                id.set("harrytmthy-dev")
+                id.set("harrytmthy")
                 name.set("Harry Timothy Tumalewa")
                 email.set("harrytmthy@gmail.com")
             }
         }
 
         scm {
-            connection.set("scm:git:git://github.com/harrytmthy-dev/safebox.git")
-            developerConnection.set("scm:git:ssh://github.com:harrytmthy-dev/safebox.git")
+            connection.set("scm:git:git://github.com/harrytmthy/safebox.git")
+            developerConnection.set("scm:git:ssh://github.com:harrytmthy/safebox.git")
             url.set("https://github.com/harrytmthy/safebox")
         }
     }


### PR DESCRIPTION
### Summary

Deprecates the old `io.github.harrytmthy-dev` namespace in the README and introduces a clear notice to guide users toward the new canonical Maven group: `io.github.harrytmthy`.

### Changes

- Replaced all "harrytmthy-dev" with "harrytmthy".
- Added a warning notice under the `## Installation` section.

Closes #45 