### PR TITLE
feat(pipeline): Enable Gradle caching to improve CI performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle.lockfile') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -86,6 +96,16 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle.lockfile') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
### Summary

This PR enables Gradle caching in the SafeBox CI pipeline to reduce build times and improve overall workflow efficiency. It adds a `Cache Gradle` step in both the `build` and `instrumented-test` jobs, caching `~/.gradle/caches` and `~/.gradle/wrapper`, using the `gradle.lockfile` hash for precise cache invalidation.

### Implementation Details

- Added `actions/cache@v4` before `setup-gradle` in both CI jobs.
- Used `gradle-${{ runner.os }}-${{ hashFiles('**/gradle.lockfile') }}` as the cache key.

Closes #47