### PR TITLE
fix: Decouple encrypted entry map from blob store

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -80,6 +80,18 @@ class SafeBoxTest {
     }
 
     @Test
+    fun getString_withRealIoDispatcher_shouldReturnCorrectValue() {
+        safeBox = createSafeBox(ioDispatcher = Dispatchers.IO)
+        safeBox.edit()
+            .putString("SafeBox", "Secured")
+            .apply()
+
+        val value = safeBox.getString("SafeBox", null)
+
+        assertEquals("Secured", value)
+    }
+
+    @Test
     fun getString_afterRemove_shouldReturnDefaultValue() {
         safeBox = createSafeBox()
         safeBox.edit()


### PR DESCRIPTION
### Summary

This PR resolves Issue #54 by realigning `apply()` behavior with EncryptedSharedPreferences (ESP), ensuring `getXxx()` calls return the expected values immediately after `.apply()` is invoked, even before disk writes complete.

This lays the foundation for performance enhancements to be explored in #55.

### Implementation Details

- **Moved encrypted entry map** (`Map<Bytes, ByteArray>`) from `SafeBoxBlobStore` to `SafeBox`, allowing immediate in-memory updates without waiting for disk writes.
- `getXxx(...)`, `contains(...)`, and `getAll()` now access a dedicated in-memory `entries` map in `SafeBox`, mirroring ESP behavior.
- Disk persistence via `SafeBoxBlobStore` is now fully decoupled from in-memory access, triggered only during `commit()` or `apply()`.
- Introduced `SafeBoxBlobStore.loadPersistedEntries()` to be called once during SafeBox's init to hydrate from disk.
- `apply()` no longer blocks `getXxx()` correctness when using real dispatchers like `Dispatchers.IO`.
- Added test case: `getString_withRealIoDispatcher_shouldReturnCorrectValue()` to verify async correctness under real-world scheduling conditions.

Closes #54