### PR TITLE
release: v1.1.2 with decoupled entries from blob store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2025-08-19
+
+### Fixed
+- **`apply()` now behaves like EncryptedSharedPreferences**: `getXxx()` calls will now return the expected values immediately after `.apply()` is invoked, even before disk writes complete. This resolves issues where values were missing if accessed right after applying edits. ([#54](https://github.com/harrytmthy/safebox/issues/54))
+
 ## [1.1.1] - 2025-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.1.1")
+    implementation("io.github.harrytmthy:safebox:1.1.2")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.1.1"
+version = "1.1.2"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
### Summary

This PR finalizes the `v1.1.2` patch release of SafeBox, addressing a behavior mismatch between `.apply()` and `getXxx()` that previously caused values to be missing when accessed immediately after applying edits.

---

### Highlights

#### Synchronous In-Memory Access
- `apply()` now guarantees that `getXxx()` returns the correct value immediately after invocation, even before persistence completes.
- Aligns SafeBox behavior with `EncryptedSharedPreferences` and resolves community-reported [#54](https://github.com/harrytmthy-dev/safebox/issues/54).

#### Refactored Internal Architecture
- The in-memory map of encrypted entries is now fully managed by `SafeBox`, decoupled from the blob store.
- Unlocks new possibilities for performance improvements in future versions.

#### Verified Fix
- Tests now verify correctness when using `Dispatchers.IO`, not just `UnconfinedTestDispatcher`.

---

🎯 Looking ahead: See [#55](https://github.com/harrytmthy-dev/safebox/issues/55) for planned optimizations to disk write strategy.