### PR TITLE
release: v1.2.0-alpha01 with improved performance, stability, and new getter APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0-alpha01] - 2025-08-25
+
+### Added
+- **Getter APIs**: `SafeBox.get(fileName)` and `SafeBox.getOrNull(fileName)` for singleton-style retrieval. ([#64](https://github.com/harrytmthy/safebox/issues/64))
+- **Gradle caching**: Improved CI performance. ([#47](https://github.com/harrytmthy/safebox/issues/47))
+
+### Behavior Changes
+- `SafeBox.create(...)` now returns the same instance for a given filename. ([#58](https://github.com/harrytmthy/safebox/issues/58))
+- Deprecated `close()` and `closeWhenIdle()`. They are now no-ops. ([#58](https://github.com/harrytmthy/safebox/issues/58))
+
+### Changed
+- **Rename** `io.github.harrytmthy-dev` → `io.github.harrytmthy`. ([#45](https://github.com/harrytmthy/safebox/issues/45))
+- **Rename** `SafeBoxExecutor` → `CipherPoolExecutor`. ([#49](https://github.com/harrytmthy/safebox/issues/49))
+
+### Docs
+- Refreshed KDoc and README. ([#63](https://github.com/harrytmthy/safebox/issues/63))
+
+### Fixed
+- Rolls up fixes from 1.1.1–1.1.3, including serialized writes to prevent overlapping `.apply()`/`.commit()`. ([#60](https://github.com/harrytmthy/safebox/issues/60), [#51](https://github.com/harrytmthy/safebox/issues/51), [#54](https://github.com/harrytmthy/safebox/issues/54))
+
 ## [1.1.3] - 2025-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.1.3")
+    implementation("io.github.harrytmthy:safebox:1.2.0-alpha01")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.1.3"
+version = "1.2.0-alpha01"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
This release introduces `v1.2.0-alpha01`, focusing on single-instance behavior and ergonomic access.

### Highlights
- **Single instance per filename**  
  `SafeBox.create(...)` is idempotent and now atomic under concurrency.
- **New getter APIs**  
  `SafeBox.get(fileName)` / `getOrNull(fileName)` enable retrieval without a `Context`.
- **Stability roll-up**  
  Includes fixes from 1.1.1–1.1.3 (e.g. serialized writes to avoid overlapping `.apply()`/`.commit()`).
- **Developer experience**  
  Gradle caching improvements for CI and KDoc/README refresh.  
  Namespace note: `io.github.harrytmthy-dev` → `io.github.harrytmthy`.

### Behavior Changes
- Repeated `create(...)` returns the same instance for a given filename.
- `close()` and `closeWhenIdle()` are deprecated and act as no-ops.