### PR TITLE
feat(startup): Add SafeBoxStartupProvider to pre-warm BouncyCastle

### DIFF
--- a/safebox/src/main/AndroidManifest.xml
+++ b/safebox/src/main/AndroidManifest.xml
@@ -14,4 +14,12 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <provider
+            android:name="com.harrytmthy.safebox.startup.SafeBoxStartupProvider"
+            android:authorities="${applicationId}.safebox-startup"
+            android:exported="false"
+            android:initOrder="100" />
+    </application>
+</manifest>

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -38,7 +38,7 @@ internal class ChaCha20CipherProvider(
     private val deterministic: Boolean,
 ) : CipherProvider {
 
-    private val cipherPool = SingletonCipherPoolProvider.getChaCha20CipherPool()
+    private val cipherPool by lazy { SingletonCipherPoolProvider.getChaCha20CipherPool() }
 
     override fun encrypt(plaintext: ByteArray): ByteArray {
         val iv = if (deterministic) {

--- a/safebox/src/main/java/com/harrytmthy/safebox/startup/SafeBoxStartupProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/startup/SafeBoxStartupProvider.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.startup
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.harrytmthy.safebox.cryptography.SingletonCipherPoolProvider
+
+internal class SafeBoxStartupProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        Thread({ SingletonCipherPoolProvider }, "SafeBox-Startup").start()
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String?>?,
+        selection: String?,
+        selectionArgs: Array<out String?>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String?>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String?>?,
+    ): Int = 0
+}


### PR DESCRIPTION
### Summary

Reduce first-use latency by pre-warming the BouncyCastle at process start.

### Implementation Details

- Add `SafeBoxStartupProvider` that asynchronously touches `Cipher.getInstance("ChaCha20-Poly1305", "BC")` on startup to warm JCA/BC.
- Make `cipherPool` in ChaCha20CipherProvider **lazy**.
- No public API changes.

Closes #69