### PR TITLE
Release/v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.4] - 2025-08-27
+
+### Fixed
+- **Serialized cryptography:** Prevents MAC check failure when multiple threads performed crypto concurrently. ([#72](https://github.com/harrytmthy/safebox/issues/72))
+
 ## [1.1.3] - 2025-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.1.3")
+    implementation("io.github.harrytmthy:safebox:1.1.4")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.1.3"
+version = "1.1.4"
 
 android {
     namespace = "com.harrytmthy.safebox"

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -223,6 +223,26 @@ class SafeBoxTest {
         assertEquals(-1, safeBox.getInt("0", -1))
     }
 
+    @Test
+    fun apply_then_commit_whenRepeatedManyTimes_shouldReturnCorrectValues() {
+        safeBox = createSafeBox(ioDispatcher = Dispatchers.IO)
+
+        safeBox.edit().apply {
+            repeat(100) {
+                putInt(it.toString(), it)
+                if (it % 2 == 0) {
+                    apply()
+                } else {
+                    commit()
+                }
+            }
+        }
+
+        repeat(100) {
+            assertEquals(it, safeBox.getInt(it.toString(), -1))
+        }
+    }
+
     private fun createSafeBox(
         ioDispatcher: CoroutineDispatcher = UnconfinedTestDispatcher(),
         stateListener: SafeBoxStateListener? = null,


### PR DESCRIPTION
### Summary

This PR finalizes the `v1.1.4` patch release of SafeBox, addressing a behavior mismatch between `.apply()` and `getXxx()` that previously caused values to be missing when accessed immediately after applying edits.

---

### Highlights

- **Serialized Cryptography**
  The synchronized encrypt/decrypt will prevent MAC check failure when multiple threads performed crypto concurrently.

Closes #72