### PR TITLE
feat: Add initial read barrier to align with SharedPreferences semantics

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
@@ -68,7 +68,7 @@ internal class SecureRandomKeyProvider private constructor(
             } ?: createNewKey()
             val secretKey = key.toSecretKey()
             decryptedKey.set(secretKey)
-            return secretKey
+            secretKey
         }
     }
 

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateManager.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateManager.kt
@@ -95,6 +95,12 @@ internal class SafeBoxStateManager(
         }
     }
 
+    internal fun awaitInitialReadBlocking() {
+        if (!initialReadCompleted.isCompleted) {
+            runBlocking { initialReadCompleted.await() }
+        }
+    }
+
     private fun updateState(newState: SafeBoxState) {
         stateListener?.onStateChanged(newState)
         SafeBoxGlobalStateObserver.updateState(fileName, newState)


### PR DESCRIPTION
### Summary

Introduce a read barrier to ensure SafeBox getters block until the initial hydration completes, matching `SharedPreferences` semantics.

### Implementation Details

- Added `awaitInitialReadBlocking()` in `SafeBoxStateManager` to synchronously await the initial read if not yet complete.
- Updated all `getXxx()` and `getAll()` accessors to invoke this barrier before returning values.

Closes #71