### PR TITLE
chore(storage): Remove initial-load strategy and stale checks from SafeBoxBlobStore

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -182,7 +182,7 @@ public class SafeBox private constructor(
      * @param fallbackStrategy The behavior to apply when access is premature
      */
     public fun setInitialLoadStrategy(fallbackStrategy: ValueFallbackStrategy) {
-        blobStore.setInitialLoadStrategy(fallbackStrategy)
+        // no-op
     }
 
     /**


### PR DESCRIPTION
### Summary

Simplify the storage layer by removing unused initial-load strategy logic from `SafeBoxBlobStore`.

### Implementation Details

- Removed `initialLoadCompleted`, `initialLoadStrategy`, and `checkInitialLoad()` from `SafeBoxBlobStore`.
- Deprecated `SafeBox.setInitialLoadStrategy(...)` as a no-op since SafeBox now gates reads/writes internally.
- Retained `writeMutex` for internal safety.

Closes #68