### PR TITLE
fix: Handle & prevent unintentional KEK rotation and dead entries

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
@@ -35,6 +35,7 @@ class ChaCha20CipherProviderTest {
     private val keyProvider = SecureRandomKeyProvider.create(
         context = context,
         fileName = "test-key",
+        keyAlias = "test-key",
         keySize = 32,
         algorithm = "ChaCha20",
         cipherProvider = AesGcmCipherProvider.create("test-gcm-alias", "test".toByteArray()),

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
@@ -41,6 +41,7 @@ class SecureRandomKeyProviderTest {
         provider = SecureRandomKeyProvider.create(
             context = context,
             fileName = "test_key",
+            keyAlias = "test_key",
             keySize = 32,
             algorithm = "ChaCha20",
             cipherProvider = cipher,
@@ -69,6 +70,7 @@ class SecureRandomKeyProviderTest {
         val newInstance = SecureRandomKeyProvider.create(
             context = context,
             fileName = "test_key",
+            keyAlias = "test_key",
             keySize = 32,
             algorithm = "ChaCha20",
             cipherProvider = AesGcmCipherProvider.create("test-gcm-alias", "test".toByteArray()),

--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -48,6 +48,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import javax.crypto.AEADBadTagException
 
 /**
  * SafeBox provides secure, high-performance key-value storage designed as a drop-in replacement
@@ -88,6 +89,8 @@ public class SafeBox private constructor(
     private val writeMutex = Mutex()
 
     private val writeBarrier = AtomicReference(CompletableDeferred<Unit>().apply { complete(Unit) })
+
+    private val scanScheduled = AtomicBoolean(false)
 
     private val delegate = object : Delegate {
 
@@ -144,7 +147,9 @@ public class SafeBox private constructor(
                 val keys = this@SafeBox.entries.keys.toHashSet()
                 this@SafeBox.entries.clear()
                 for (encryptedKey in keys) {
-                    val key = keyCipherProvider.decrypt(encryptedKey.value).toString(Charsets.UTF_8)
+                    val key = keyCipherProvider.tryDecrypt(encryptedKey.value)
+                        ?.toString(Charsets.UTF_8)
+                        ?: continue
                     listeners.forEach { it.onSharedPreferenceChanged(this@SafeBox, key) }
                 }
             }
@@ -237,8 +242,10 @@ public class SafeBox private constructor(
     override fun getAll(): Map<String, Any?> {
         val decryptedEntries = HashMap<String, Any?>(entries.size, 1f)
         for (entry in entries) {
-            val key = keyCipherProvider.decrypt(entry.key.value).toString(Charsets.UTF_8)
-            val value = valueCipherProvider.decrypt(entry.value)
+            val key = keyCipherProvider.tryDecrypt(entry.key.value)
+                ?.toString(Charsets.UTF_8)
+                ?: continue
+            val value = valueCipherProvider.tryDecrypt(entry.value) ?: continue
             decryptedEntries[key] = byteDecoder.decodeAny(value)
         }
         return decryptedEntries
@@ -293,7 +300,7 @@ public class SafeBox private constructor(
 
     private fun getDecryptedValue(key: String): ByteArray? =
         entries[key.toEncryptedKey()]
-            ?.let(valueCipherProvider::decrypt)
+            ?.let { valueCipherProvider.tryDecrypt(it) }
 
     private suspend fun applyChanges(entries: LinkedHashMap<String, Action>, cleared: Boolean) {
         if (cleared) {
@@ -315,6 +322,43 @@ public class SafeBox private constructor(
             }
         }
     }
+
+    private fun scanAndRemoveDeadEntries() {
+        if (!scanScheduled.compareAndSet(false, true)) {
+            return
+        }
+        val currentWriteBarrier = CompletableDeferred<Unit>()
+        val previousWriteBarrier = writeBarrier.getAndSet(currentWriteBarrier)
+        stateManager.launchApplyWithWritingState {
+            try {
+                previousWriteBarrier.await()
+                val deadKeys = ArrayList<Bytes>()
+                for ((encryptedKey, encryptedValue) in entries) {
+                    if (valueCipherProvider.tryDecrypt(encryptedValue) == null) {
+                        entries.remove(encryptedKey)
+                        deadKeys.add(encryptedKey)
+                    }
+                }
+                if (deadKeys.isNotEmpty()) {
+                    writeMutex.withLock {
+                        blobStore.delete(*deadKeys.toTypedArray())
+                    }
+                }
+            } finally {
+                currentWriteBarrier.complete(Unit)
+                scanScheduled.set(false)
+            }
+        }
+    }
+
+    private fun CipherProvider.tryDecrypt(encryptedValue: ByteArray): ByteArray? =
+        try {
+            decrypt(encryptedValue)
+        } catch (e: AEADBadTagException) {
+            Log.e("SafeBox", "Decrypt failed due to AEADBadTagException.", e)
+            scanAndRemoveDeadEntries()
+            null
+        }
 
     private fun String.toEncryptedKey(): Bytes =
         keyCipherProvider.encrypt(this.toByteArray()).toBytes()
@@ -375,10 +419,67 @@ public class SafeBox private constructor(
         @VisibleForTesting
         internal const val DEFAULT_KEY_ALIAS = "SafeBoxKey"
 
-        @VisibleForTesting
         internal const val DEFAULT_VALUE_KEYSTORE_ALIAS = "SafeBoxValue"
 
         /**
+         * Creates a [SafeBox] instance with secure defaults:
+         * - Keys are deterministically encrypted using [ChaCha20CipherProvider].
+         * - Values are encrypted with the same ChaCha20 key, but with randomized IV per encryption.
+         * - The ChaCha20 secret is encrypted using AES-GCM via [SecureRandomKeyProvider].
+         *
+         * This method handles secure initialization and is recommended for most use cases.
+         *
+         * **Common pitfalls:**
+         * - Do NOT create multiple SafeBox instances with the same file name.
+         * - Avoid scoping SafeBox to short-lived components (e.g. ViewModel).
+         *
+         * @param context The application context
+         * @param fileName The name of the backing file used for persistence
+         * @param keyAlias The identifier for storing the key (used to locate its encrypted form)
+         * @param valueKeyStoreAlias The Android Keystore alias used for AES-GCM key generation
+         * @param ioDispatcher The dispatcher used for I/O operations (default: [Dispatchers.IO])
+         * @param stateListener The listener to observe instance-bound state transitions
+         *
+         * @return A fully configured [SafeBox] instance
+         * @throws IllegalStateException if the file is already registered.
+         */
+        @JvmOverloads
+        @JvmStatic
+        @Throws(IllegalStateException::class)
+        public fun create(
+            context: Context,
+            fileName: String,
+            keyAlias: String = DEFAULT_KEY_ALIAS,
+            valueKeyStoreAlias: String = DEFAULT_VALUE_KEYSTORE_ALIAS,
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+            stateListener: SafeBoxStateListener? = null,
+        ): SafeBox {
+            SafeBoxBlobFileRegistry.register(fileName)
+            val aesGcmCipherProvider = AesGcmCipherProvider.create(
+                alias = valueKeyStoreAlias,
+                aad = fileName.toByteArray(),
+            )
+            val keyProvider = SecureRandomKeyProvider.create(
+                context = context,
+                fileName = fileName,
+                keyAlias = keyAlias,
+                keySize = ChaCha20CipherProvider.KEY_SIZE,
+                algorithm = ChaCha20CipherProvider.ALGORITHM,
+                cipherProvider = aesGcmCipherProvider,
+            )
+            val keyCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = true)
+            val valueCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = false)
+            val stateManager = SafeBoxStateManager(fileName, stateListener, ioDispatcher)
+            val blobStore = SafeBoxBlobStore.create(context, fileName)
+            return SafeBox(blobStore, keyCipherProvider, valueCipherProvider, stateManager)
+        }
+
+        /**
+         * **Deprecation:** SafeBox no longer supports custom AAD. Changing it can cause MAC check
+         * failures and dead entries. Consequently, `additionalAuthenticatedData` is ignored, and
+         * this overload will be removed in v1.3. `keyAlias` and `valueKeyStoreAlias` are planned
+         * for deprecation in v1.3.
+         *
          * Creates a [SafeBox] instance with secure defaults:
          * - Keys are deterministically encrypted using [ChaCha20CipherProvider].
          * - Values are encrypted with the same ChaCha20 key, but with randomized IV per encryption.
@@ -401,6 +502,7 @@ public class SafeBox private constructor(
          * @return A fully configured [SafeBox] instance
          * @throws IllegalStateException if the file is already registered.
          */
+        @Deprecated("additionalAuthenticatedData is ignored. Use the overload without it.")
         @JvmOverloads
         @JvmStatic
         @Throws(IllegalStateException::class)
@@ -409,28 +511,11 @@ public class SafeBox private constructor(
             fileName: String,
             keyAlias: String = DEFAULT_KEY_ALIAS,
             valueKeyStoreAlias: String = DEFAULT_VALUE_KEYSTORE_ALIAS,
-            additionalAuthenticatedData: ByteArray = fileName.toByteArray(),
+            additionalAuthenticatedData: ByteArray,
             ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
             stateListener: SafeBoxStateListener? = null,
-        ): SafeBox {
-            SafeBoxBlobFileRegistry.register(fileName)
-            val aesGcmCipherProvider = AesGcmCipherProvider.create(
-                alias = valueKeyStoreAlias,
-                aad = additionalAuthenticatedData,
-            )
-            val keyProvider = SecureRandomKeyProvider.create(
-                context = context,
-                fileName = keyAlias,
-                keySize = ChaCha20CipherProvider.KEY_SIZE,
-                algorithm = ChaCha20CipherProvider.ALGORITHM,
-                cipherProvider = aesGcmCipherProvider,
-            )
-            val keyCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = true)
-            val valueCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = false)
-            val stateManager = SafeBoxStateManager(fileName, stateListener, ioDispatcher)
-            val blobStore = SafeBoxBlobStore.create(context, fileName)
-            return SafeBox(blobStore, keyCipherProvider, valueCipherProvider, stateManager)
-        }
+        ): SafeBox =
+            create(context, fileName, keyAlias, valueKeyStoreAlias, ioDispatcher, stateListener)
 
         /**
          * Creates a [SafeBox] instance using a custom [CipherProvider] implementation.

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
@@ -65,6 +65,12 @@ internal class AesGcmCipherProvider private constructor(
         return cipher.doFinal(actualData)
     }
 
+    override fun rotateKey() {
+        keyProvider.rotateKey()
+    }
+
+    override fun shouldRotateKey(): Boolean = keyProvider.shouldRotateKey()
+
     internal companion object {
 
         private const val TRANSFORMATION = "AES/GCM/NoPadding"

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
@@ -39,6 +39,18 @@ public interface CipherProvider {
     fun decrypt(ciphertext: ByteArray): ByteArray
 
     /**
+     * Triggers key rotation by replacing the existing key with a new one.
+     */
+    fun rotateKey() = Unit
+
+    /**
+     * Decides whether or not key rotation must be done.
+     *
+     * @return `true` if key rotation must be done. `false` otherwise.
+     */
+    fun shouldRotateKey(): Boolean = false
+
+    /**
      * Destroys any associated cryptographic key material. This method is called when SafeBox
      * is permanently closed to prevent key leakage from memory.
      *

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
@@ -36,6 +36,18 @@ internal interface KeyProvider {
     fun getOrCreateKey(): SecretKey
 
     /**
+     * Triggers key rotation by replacing the existing key with a new one.
+     */
+    fun rotateKey() = Unit
+
+    /**
+     * Decides whether or not key rotation must be done.
+     *
+     * @return `true` if key rotation must be done. `false` otherwise.
+     */
+    fun shouldRotateKey(): Boolean = false
+
+    /**
      * Destroys any in-memory key material held by the implementation.
      * This is typically used during shutdown to ensure sensitive key data is wiped from memory.
      */

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/SafeSecretKey.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/SafeSecretKey.kt
@@ -82,7 +82,7 @@ internal class SafeSecretKey(
             lastCopy.get()?.let { return it } // fast path after lock acquisition
             val copy = keyBuffer.toByteArray().xorInPlace(mask)
             lastCopy.set(copy)
-            return copy
+            copy
         }
     }
 

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
@@ -22,6 +22,7 @@ import android.util.Log
 import com.harrytmthy.safebox.cryptography.CipherProvider
 import com.harrytmthy.safebox.cryptography.SecureRandomProvider
 import java.io.File
+import java.io.IOException
 import java.security.GeneralSecurityException
 import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicReference
@@ -51,6 +52,20 @@ internal class SecureRandomKeyProvider private constructor(
 
     private val lock = Any()
 
+    init {
+        if (cipherProvider.shouldRotateKey() && encryptedKeyBytes.isNotEmpty()) {
+            try {
+                val key = cipherProvider.decrypt(encryptedKeyBytes)
+                cipherProvider.rotateKey()
+                val encryptedKey = cipherProvider.encrypt(key)
+                replaceFileAtomically(encryptedKey)
+                encryptedKeyBytes = encryptedKey
+            } catch (e: Exception) {
+                Log.e("SafeBox", "Failed to rewrap DEK.", e)
+            }
+        }
+    }
+
     /**
      * Retrieves or generates the symmetric key, decrypting from disk if necessary.
      * The key is cached in memory for a short period before being cleared.
@@ -68,8 +83,13 @@ internal class SecureRandomKeyProvider private constructor(
             } ?: createNewKey()
             val secretKey = key.toSecretKey()
             decryptedKey.set(secretKey)
-            return secretKey
+            secretKey
         }
+    }
+
+    override fun rotateKey() {
+        val newKey = createNewKey().toSecretKey()
+        decryptedKey.set(newKey)
     }
 
     override fun destroyKey() {
@@ -80,9 +100,29 @@ internal class SecureRandomKeyProvider private constructor(
     private fun createNewKey(): ByteArray {
         val generatedKey = SecureRandomProvider.generate(keySize)
         val encryptedKey = cipherProvider.encrypt(generatedKey)
+        replaceFileAtomically(encryptedKey)
         encryptedKeyBytes = encryptedKey
-        encryptedKeyFile.writeBytes(encryptedKey)
         return generatedKey
+    }
+
+    private fun replaceFileAtomically(encryptedKey: ByteArray) {
+        val directory = encryptedKeyFile.parentFile ?: error("Missing parent directory")
+        val temporaryFile = File(directory, encryptedKeyFile.name + ".tmp")
+        try {
+            temporaryFile.outputStream().use { outputStream ->
+                outputStream.write(encryptedKey)
+                outputStream.fd.sync()
+            }
+            if (temporaryFile.renameTo(encryptedKeyFile)) {
+                return
+            }
+            encryptedKeyFile.delete()
+            if (!temporaryFile.renameTo(encryptedKeyFile)) {
+                error("Failed to persist wrapped DEK atomically.")
+            }
+        } finally {
+            temporaryFile.delete()
+        }
     }
 
     private fun ByteArray.toSecretKey(): SecretKey {
@@ -95,15 +135,43 @@ internal class SecureRandomKeyProvider private constructor(
         internal fun create(
             context: Context,
             fileName: String,
+            keyAlias: String,
             keySize: Int,
             algorithm: String,
             cipherProvider: CipherProvider,
         ): SecureRandomKeyProvider {
-            val file = File(context.noBackupFilesDir, "$fileName.bin")
-            if (!file.exists()) {
-                file.createNewFile()
-            }
+            val file = getEncryptedKeyFile(context, fileName, keyAlias)
             return SecureRandomKeyProvider(file, keySize, algorithm, cipherProvider)
+        }
+
+        private fun getEncryptedKeyFile(
+            context: Context,
+            fileName: String,
+            keyAlias: String,
+        ): File {
+            val oldDestination = File(context.noBackupFilesDir, "$keyAlias.bin")
+            val newDestination = File(context.noBackupFilesDir, "$fileName.key.bin")
+            if (newDestination.exists() && newDestination.length() > 0L) {
+                return newDestination
+            }
+            newDestination.createNewFile()
+            if (!oldDestination.exists()) {
+                return newDestination
+            }
+            try {
+                oldDestination.inputStream().use { input ->
+                    newDestination.outputStream().use { output ->
+                        input.copyTo(output)
+                        output.fd.sync()
+                    }
+                }
+            } catch (e: IOException) {
+                Log.e("SafeBox", "Failed to migrate wrapped DEK.", e)
+                newDestination.delete()
+                return oldDestination
+            }
+            oldDestination.delete()
+            return newDestination
         }
     }
 }


### PR DESCRIPTION
### Summary

The overall fix consists of 2 parts:

- **Handling**
  - On AEAD failures, `tryDecrypt()` schedules `scanAndRemoveDeadEntries()` to purge dead entries safely.

- **Prevention**
  - One-time DEK rewrap to the default KEK alias when a legacy alias exists.
  - Wrapped DEK file redirected from `$keyAlias.bin` to `$fileName.key.bin` with atomic persistence.
  - AAD fixed to `fileName.toByteArray()`; deprecate AAD-taking `create(...)` overload.

### Implementation Details

- **AndroidKeyStoreKeyProvider**
  - `shouldRotateKey()` is true if default alias is missing or legacy alias exists.
  - `rotateKey()` provisions default alias and deletes the legacy alias to mark migration complete.

- **AesGcmCipherProvider**
  - Forwards `rotateKey()` and `shouldRotateKey()` to the underlying `KeyProvider`.

- **SecureRandomKeyProvider**
  - Rewrap in `init`: decrypt with legacy KEK → rotate to default KEK → re-encrypt → `replaceFileAtomically(...)` → update `encryptedKeyBytes` → cache `SecretKey` derived from the **new** ciphertext.
  - `rotateKey()` generates a new DEK and swaps the cached key under lock.

- **SafeBox**
  - `create(...)`: binds AAD to file name, deprecates AAD-taking overload.
  - `tryDecrypt(...)`: catches AEAD and triggers dead-entry scan.

Refs #72