### PR TITLE
release: v1.2.0-alpha02 with read parity and safe alias/AAD handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0-alpha02] - 2025-08-29
+
+### Behavior Changes
+- **SharedPreferences parity for reads:** `getXxx()` now blocks until the initial load completes. ([#71](https://github.com/harrytmthy/safebox/issues/71))
+
+### Fixed
+- **Handle & prevent dead entries:** Carry-over from 1.1.5. Prevents unintentional KEK rotations. When `AEADBadTagException` occurs, SafeBox purges unreadable values safely. ([#72](https://github.com/harrytmthy/safebox/issues/72))
+
+### Deprecated
+- **CipherPool** and **CipherPoolExecutor:** Planned for removal in **v1.3**. ([#78](https://github.com/harrytmthy/safebox/issues/78))
+- **AAD-taking factory:** AAD is now ignored and planned for removal in **v1.3**. ([#72](https://github.com/harrytmthy/safebox/issues/72))
+- **`setInitialLoadStrategy(...)`:** Now a no-op. Planned for removal in **v1.3**. ([#68](https://github.com/harrytmthy/safebox/issues/68))
+
+### Removed
+- **SingletonCipherPoolProvider:** Stale internal helper that supported CipherPool. ([#78](https://github.com/harrytmthy/safebox/issues/78))
+
 ## [1.2.0-alpha01] - 2025-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.2.0-alpha01")
+    implementation("io.github.harrytmthy:safebox:1.2.0-alpha02")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.2.0-alpha01"
+version = "1.2.0-alpha02"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
This release introduces `v1.2.0-alpha02`, focusing on read parity with SharedPreferences and safer `create(...)` across alias/AAD changes.

### Highlights
- **Read parity**  
  `getXxx()` now waits for the initial load to finish. Matches SharedPreferences behavior.
- **Safe `create(...)` with alias/AAD changes**  
  Silent KEK migration prevents unintended rotations. Unreadable values are cleaned up on `AEADBadTagException`.
- **API cleanup**  
  `CipherPool` and `CipherPoolExecutor` are deprecated. `setInitialLoadStrategy(...)` is now a no-op. The AAD-taking factory is deprecated.

### Behavior Changes
- Reads block until the initial hydrate completes.
- Initial-load strategy is removed from the data layer.

### Deprecated
- `CipherPool` and `CipherPoolExecutor`. Planned removal in v1.3.
- `SafeBox.create(...)` overload with `additionalAuthenticatedData`. AAD is ignored. Planned removal in v1.3.
- `setInitialLoadStrategy(...)`. No-op. Planned removal in v1.3.