### PR TITLE
fix(editor): Reset cleared flag after commit/apply

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -246,6 +246,18 @@ class SafeBoxTest {
     }
 
     @Test
+    fun getFloat_afterClear_withReusedEditor_shouldBeRetained() {
+        safeBox = createSafeBox()
+        val editor = safeBox.edit()
+        editor.clear().commit()
+
+        editor.putFloat("key1", 1.234f).commit()
+        editor.putBoolean("key2", true).commit()
+
+        assertEquals(1.234f, safeBox.getFloat("key1", 0f))
+    }
+
+    @Test
     fun commit_shouldWaitForApplyCompletion() {
         safeBox = createSafeBox()
         safeBox.edit().apply {

--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -190,10 +190,10 @@ public class SafeBox private constructor(
             apply { cleared.set(true) }
 
         override fun commit(): Boolean =
-            engine.commitBatch(actions, cleared.get())
+            engine.commitBatch(actions, cleared.getAndSet(false))
 
         override fun apply() {
-            engine.applyBatch(actions, cleared.get())
+            engine.applyBatch(actions, cleared.getAndSet(false))
         }
     }
 


### PR DESCRIPTION
### Summary

Fix stale `clear()` flag when reusing `SharedPreferences.Editor`. Preserving an editor instance after calling `clear()` caused unintended full wipes on subsequent `commit()`/`apply()` calls.

### Implementation Details

- Replace `cleared.get()` with `cleared.getAndSet(false)`.
- Add a test to cover the edge case.

Closes #86