### PR TITLE
fix(crypto): Prevent AEADBadTagException via a process-wide mutex

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -340,19 +340,18 @@ class SafeBoxTest {
     fun apply_then_commit_whenRepeatedManyTimes_shouldReturnCorrectValues() {
         safeBox = createSafeBox(ioDispatcher = Dispatchers.IO)
 
-        safeBox.edit().apply {
-            repeat(100) {
-                putInt(it.toString(), it)
-                if (it % 2 == 0) {
-                    apply()
-                } else {
-                    commit()
+        repeat(50) {
+            safeBox.edit().apply {
+                repeat(100) {
+                    putInt(it.toString(), it).apply()
                 }
             }
         }
 
-        repeat(100) {
-            assertEquals(it, safeBox.getInt(it.toString(), -1))
+        repeat(50) {
+            repeat(100) {
+                assertEquals(it, safeBox.getInt(it.toString(), -1))
+            }
         }
     }
 

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -51,8 +51,6 @@ internal class ChaCha20CipherProvider(
         }
     }
 
-    private val cipherLock = Any()
-
     override fun encrypt(plaintext: ByteArray): ByteArray =
         synchronized(cipherLock) {
             val iv = if (deterministic) {
@@ -90,5 +88,6 @@ internal class ChaCha20CipherProvider(
         internal const val TRANSFORMATION = "ChaCha20-Poly1305"
         private const val IV_SIZE = 12
         private const val MAC_SIZE_BITS = 128
+        private val cipherLock = Any()
     }
 }


### PR DESCRIPTION
### Summary

Replace the per-instance cipher lock with a process-wide mutex in `ChaCha20CipherProvider` to stop `AEADBadTagException` under concurrent `apply()` and read workloads.

### Implementation Details

- Added a single static lock inside `ChaCha20CipherProvider` and guard both `encrypt` and `decrypt`.
- Verified with the flood-apply test and a read assertion loop. No AEAD errors.

Closes #90