### PR TITLE
perf(engine): Improve engine write performance by shrinking critical update paths

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -337,7 +337,7 @@ class SafeBoxTest {
     }
 
     @Test
-    fun apply_then_commit_whenRepeatedManyTimes_shouldReturnCorrectValues() {
+    fun apply_whenRepeatedManyTimes_shouldReturnCorrectValues() {
         safeBox = createSafeBox(ioDispatcher = Dispatchers.IO)
 
         repeat(50) {

--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -69,13 +69,10 @@ public class SafeBox private constructor(
 
     private val listeners = CopyOnWriteArrayList<OnSharedPreferenceChangeListener>()
 
-    init {
-        val callback = object : SafeBoxEngine.Callback {
-            override fun onEntryChanged(key: String) {
-                listeners.forEach { it.onSharedPreferenceChanged(this@SafeBox, key) }
-            }
+    private val callback = object : SafeBoxEngine.Callback {
+        override fun onEntryChanged(key: String) {
+            listeners.forEach { it.onSharedPreferenceChanged(this@SafeBox, key) }
         }
-        engine.setCallback(callback)
     }
 
     /**
@@ -152,11 +149,18 @@ public class SafeBox private constructor(
     override fun edit(): SharedPreferences.Editor = Editor(engine)
 
     override fun registerOnSharedPreferenceChangeListener(l: OnSharedPreferenceChangeListener) {
+        val shouldSetCallback = listeners.isEmpty()
         listeners.add(l)
+        if (shouldSetCallback) {
+            engine.setCallback(callback)
+        }
     }
 
     override fun unregisterOnSharedPreferenceChangeListener(l: OnSharedPreferenceChangeListener) {
         listeners.remove(l)
+        if (listeners.isEmpty()) {
+            engine.setCallback(null)
+        }
     }
 
     private class Editor(private val engine: SafeBoxEngine) : SharedPreferences.Editor {


### PR DESCRIPTION
### Summary

Skip no-op batches, shorten critical sections around `updateEntries`, and gate clear-path notifications behind the presence of a listener callback.

Closes #92