### PR TITLE
release: v1.2.0-rc01 with faster engine writes and updated benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0-rc01] - 2025-08-31
+
+### Fixed
+- **Prevent AEADBadTagException under concurrency:** ChaCha20-Poly1305 operations now use a **process-wide mutex** (instead of per-instance locking), eliminating MAC failures and dead entries during mixed read/write workloads. ([#90](https://github.com/harrytmthy/safebox/issues/90))
+
+### Performance
+- **Faster write paths:** Shrinks critical update sections and reduces lock contention on bursty `apply()`/`commit()` sequences, improving end-to-end write latency. ([#92](https://github.com/harrytmthy/safebox/issues/92))
+
+### Docs
+- **Benchmarks & KDoc refresh:** Updated v1.2.0 benchmark charts & tables in README, and updated KDocs. ([#89](https://github.com/harrytmthy/safebox/issues/89))
+
 ## [1.2.0-beta01] - 2025-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.2.0-beta01")
+    implementation("io.github.harrytmthy:safebox:1.2.0-rc01")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.2.0-beta01"
+version = "1.2.0-rc01"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
This release introduces `v1.2.0-rc01`, focusing on stability under concurrency and faster write paths, plus refreshed docs/benchmarks.

### Highlights
- **Prevent AEADBadTagException under concurrency**  
  ChaCha20-Poly1305 operations now use a **process-wide mutex**, eliminating MAC failures and dead entries during mixed read/write workloads. ([#90](https://github.com/harrytmthy/safebox/issues/90))

- **Faster engine writes**  
  Shrinks critical update sections and reduces lock contention on bursty `apply()`/`commit()` sequences. ([#92](https://github.com/harrytmthy/safebox/issues/92))

- **Benchmarks & KDoc refresh**  
  Updated v1.2.0 charts & tables in README, and simplified KDocs. ([#89](https://github.com/harrytmthy/safebox/issues/89))