### PR TITLE
release: v1.2.0 with SafeBoxEngine, faster writes, and concurrency-stable crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-09-01
+
+### Added
+- **Getter APIs:** `SafeBox.get(fileName)` and `SafeBox.getOrNull(fileName)` for singleton-style retrieval. ([#64](https://github.com/harrytmthy/safebox/issues/64))
+
+### Changed
+- **Namespace update:** Published under `io.github.harrytmthy`. ([#45](https://github.com/harrytmthy/safebox/issues/45))
+- **Single instance per filename:** `SafeBox.create(...)` is atomic and idempotent. Repeated calls return the same instance. ([#58](https://github.com/harrytmthy/safebox/issues/58))
+- **SharedPreferences parity for reads:** `getXxx()` now blocks until the initial load completes. ([#71](https://github.com/harrytmthy/safebox/issues/71))
+- **Centralized runtime orchestration:** New internal `SafeBoxEngine` owns in-memory entries, the initial-load barrier, write sequencing, and AEAD dead-entry purge scheduling. ([#84](https://github.com/harrytmthy/safebox/issues/84), [#82](https://github.com/harrytmthy/safebox/issues/82))
+- **Faster engine writes:** Shrinks critical sections and lowers lock contention during bursty apply or commit. ([#92](https://github.com/harrytmthy/safebox/issues/92))
+- **Docs refreshed:** README and KDocs updated with v1.2.0 benchmarks. ([#63](https://github.com/harrytmthy/safebox/issues/63), [#89](https://github.com/harrytmthy/safebox/issues/89))
+
+### Fixed
+- **AEADBadTagException under concurrency:** ChaCha20-Poly1305 guarded by a process-wide mutex. Removes MAC failures and dead entries during mixed read and write workloads. ([#90](https://github.com/harrytmthy/safebox/issues/90))
+- **Persisted clear flag:** Reusing an editor after `clear()` no longer keeps clearing on later commits. ([#86](https://github.com/harrytmthy/safebox/issues/86))
+- **Stability carry-overs:** Serialized cryptography and safe purge of unreadable values. ([#72](https://github.com/harrytmthy/safebox/issues/72))
+
+### Deprecated
+- **CipherPool and CipherPoolExecutor:** Removal planned in v1.3. ([#78](https://github.com/harrytmthy/safebox/issues/78))
+- **AAD-taking factory:** AAD is ignored in v1.2 and removal is planned in v1.3. ([#72](https://github.com/harrytmthy/safebox/issues/72))
+- **`setInitialLoadStrategy(...)`:** No-op in v1.2 and removal planned in v1.3. ([#68](https://github.com/harrytmthy/safebox/issues/68))
+
+### Removed
+- **SafeBoxStateManager:** Responsibilities moved into `SafeBoxEngine`. ([#84](https://github.com/harrytmthy/safebox/issues/84))
+- **SingletonCipherPoolProvider:** Stale internal helper removed. ([#78](https://github.com/harrytmthy/safebox/issues/78))
+
+### Internal
+- **CI:** Gradle caching improvements. ([#47](https://github.com/harrytmthy/safebox/issues/47))
+- **Rename:** `SafeBoxExecutor` to `CipherPoolExecutor`. ([#49](https://github.com/harrytmthy/safebox/issues/49))
+
 ## [1.2.0-rc01] - 2025-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.2.0-rc01")
+    implementation("io.github.harrytmthy:safebox:1.2.0")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.2.0-rc01"
+version = "1.2.0"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
### Summary

This PR finalizes the v1.2.0 release of SafeBox. The update delivers centralized runtime orchestration, faster write paths, and stable cryptography under concurrency. Documentation and benchmarks are refreshed.

---

### Highlights

#### Centralized orchestration
- **SafeBoxEngine:** Owns in-memory entries, the initial-load barrier, write sequencing, and AEAD dead-entry purge. Also triggers per-key change notifications. ([#84](https://github.com/harrytmthy/safebox/issues/84), [#82](https://github.com/harrytmthy/safebox/issues/82))

#### Concurrency stability
- **ChaCha20-Poly1305 mutex:** Guarded by a process-wide lock to prevent AEADBadTagException under mixed read and write workloads. ([#90](https://github.com/harrytmthy/safebox/issues/90))

#### Performance
- **Faster engine writes:** Smaller critical sections and reduced lock contention during bursty apply or commit. ([#92](https://github.com/harrytmthy/safebox/issues/92))
- **Docs and benchmarks:** README and KDocs updated with v1.2.0 performance results. ([#89](https://github.com/harrytmthy/safebox/issues/89))

#### API ergonomics and behavior
- **SharedPreferences parity for reads:** `getXxx()` waits for initial load. ([#71](https://github.com/harrytmthy/safebox/issues/71))
- **Single instance per filename:** `SafeBox.create(...)` is idempotent. ([#58](https://github.com/harrytmthy/safebox/issues/58))
- **Getter APIs:** `SafeBox.get(...)` and `SafeBox.getOrNull(...)`. ([#64](https://github.com/harrytmthy/safebox/issues/64))

#### Cleanups
- **Deprecations:** `CipherPool`, `CipherPoolExecutor`, `setInitialLoadStrategy(...)`, and the AAD-taking factory. Removal planned in v1.3. ([#78](https://github.com/harrytmthy/safebox/issues/78), [#68](https://github.com/harrytmthy/safebox/issues/68), [#72](https://github.com/harrytmthy/safebox/issues/72))
- **Removals:** `SafeBoxStateManager` and `SingletonCipherPoolProvider`. ([#84](https://github.com/harrytmthy/safebox/issues/84), [#78](https://github.com/harrytmthy/safebox/issues/78))