### PR TITLE
refactor(decoder): Transfer castFailureStrategy ownership to ByteDecoder

### DIFF
--- a/safebox/src/test/java/com/harrytmthy/safebox/extensions/ByteExtensionsTest.kt
+++ b/safebox/src/test/java/com/harrytmthy/safebox/extensions/ByteExtensionsTest.kt
@@ -18,15 +18,12 @@ package com.harrytmthy.safebox.extensions
 
 import com.harrytmthy.safebox.constants.ValueTypeTag
 import com.harrytmthy.safebox.decoder.ByteDecoder
-import com.harrytmthy.safebox.strategy.ValueFallbackStrategy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ByteExtensionsTest {
 
-    private val fallbackStrategy = ValueFallbackStrategy.WARN
-
-    private val byteDecoder = ByteDecoder(::fallbackStrategy)
+    private val byteDecoder = ByteDecoder()
 
     @Test
     fun `Int encode-decode should return original value`() {


### PR DESCRIPTION
### Summary

Move `castFailureStrategy` into `ByteDecoder`, add a setter, and delegate updates through `SafeBoxEngine`. Remove the unnecessary `AtomicReference` from `SafeBox` and keep the existing public method delegating internally.

Closes #98