### PR TITLE
chore: Support deterministic test setup & teardown via internal constructor & channel closure

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -238,26 +238,16 @@ public class SafeBox private constructor(private val engine: SafeBoxEngine) : Sh
             ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
             stateListener: SafeBoxStateListener? = null,
         ): SafeBox {
-            instances[fileName]?.let { safeBox ->
-                stateListener?.let(safeBox.engine::setStateListener)
-                return safeBox
-            }
-            return synchronized(instances) {
-                instances[fileName]?.let { safeBox ->
-                    stateListener?.let(safeBox.engine::setStateListener)
-                    return safeBox
-                }
-                val engine = SafeBoxEngine.create(
-                    context = context,
-                    fileName = fileName,
-                    keyAlias = keyAlias,
-                    valueKeyStoreAlias = valueKeyStoreAlias,
-                    aad = fileName.toByteArray(),
-                    ioDispatcher = ioDispatcher,
-                    stateListener = stateListener,
-                )
-                SafeBox(engine).also { instances[fileName] = it }
-            }
+            val engine = SafeBoxEngine.create(
+                context = context,
+                fileName = fileName,
+                keyAlias = keyAlias,
+                valueKeyStoreAlias = valueKeyStoreAlias,
+                aad = fileName.toByteArray(),
+                ioDispatcher = ioDispatcher,
+                stateListener = stateListener,
+            )
+            return createInternal(fileName, stateListener, engine)
         }
 
         /**
@@ -329,6 +319,22 @@ public class SafeBox private constructor(private val engine: SafeBoxEngine) : Sh
             ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
             stateListener: SafeBoxStateListener? = null,
         ): SafeBox {
+            val engine = SafeBoxEngine.create(
+                context = context,
+                fileName = fileName,
+                keyCipherProvider = keyCipherProvider,
+                valueCipherProvider = valueCipherProvider,
+                ioDispatcher = ioDispatcher,
+                stateListener = stateListener,
+            )
+            return createInternal(fileName, stateListener, engine)
+        }
+
+        internal fun createInternal(
+            fileName: String,
+            stateListener: SafeBoxStateListener?,
+            engine: SafeBoxEngine,
+        ): SafeBox {
             instances[fileName]?.let { safeBox ->
                 stateListener?.let(safeBox.engine::setStateListener)
                 return safeBox
@@ -338,14 +344,6 @@ public class SafeBox private constructor(private val engine: SafeBoxEngine) : Sh
                     stateListener?.let(safeBox.engine::setStateListener)
                     return safeBox
                 }
-                val engine = SafeBoxEngine.create(
-                    context = context,
-                    fileName = fileName,
-                    keyCipherProvider = keyCipherProvider,
-                    valueCipherProvider = valueCipherProvider,
-                    ioDispatcher = ioDispatcher,
-                    stateListener = stateListener,
-                )
                 SafeBox(engine).also { instances[fileName] = it }
             }
         }

--- a/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
@@ -267,6 +267,14 @@ internal class SafeBoxEngine private constructor(
         }
     }
 
+    internal fun closeBlobStoreChannel() {
+        runBlocking {
+            initialReadCompleted.await()
+            writeBarrier.get().await()
+            blobStore.closeWhenIdle()
+        }
+    }
+
     private fun updateState(newState: SafeBoxState) {
         stateListener?.onStateChanged(newState)
         SafeBoxGlobalStateObserver.updateState(blobStore.getFileName(), newState)

--- a/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
@@ -152,6 +152,15 @@ internal class SafeBoxBlobStore private constructor(private val file: File) {
      */
     internal fun getFileName(): String = file.nameWithoutExtension
 
+    /**
+     * Closes the underlying file channel and releases associated resources.
+     */
+    internal suspend fun closeWhenIdle() {
+        writeMutex.withLock {
+            channel.close()
+        }
+    }
+
     private fun writeAtOffset(
         encryptedKey: Bytes,
         encryptedValue: ByteArray,


### PR DESCRIPTION
### Summary

Add internal hooks for deterministic test setup and teardown without reviving public close APIs.

### Implementation Details

- Added `SafeBox.createInternal(fileName, stateListener, engine)` and routed public `create(...)` overloads through it.
- Added an internal `SafeBoxEngine.closeBlobStoreChannel()` that awaits initial hydrate and the current write barrier before calling `SafeBoxBlobStore.closeWhenIdle()`.
- Cleaned up resources to ensure deterministic test setup & teardown.

Closes #100