### PR TITLE
fix: Match SharedPreferences listener semantics

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -62,7 +62,7 @@ public class SafeBox private constructor(private val engine: SafeBoxEngine) : Sh
     private val listeners = CopyOnWriteArrayList<OnSharedPreferenceChangeListener>()
 
     private val callback = object : SafeBoxEngine.Callback {
-        override fun onEntryChanged(key: String) {
+        override fun onEntryChanged(key: String?) {
             listeners.forEach { it.onSharedPreferenceChanged(this@SafeBox, key) }
         }
     }


### PR DESCRIPTION
### Summary

Bring SafeBox change notifications in line with platform `SharedPreferences`.

Closes #102