### PR TITLE
refactor: Remove alias-based fields

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProviderTest.kt
@@ -29,7 +29,7 @@ class AesGcmCipherProviderTest {
     @Test
     fun encryptAndDecrypt_withGCM_shouldReturnOriginalPlaintext() {
         val aad = "AndroidAAD".toByteArray()
-        val provider = AesGcmCipherProvider.create("test-gcm-alias", aad)
+        val provider = AesGcmCipherProvider.create(aad)
         val plaintext = "This is GCM from AndroidKeyStore".toByteArray()
 
         val encrypted = provider.encrypt(plaintext)
@@ -41,7 +41,7 @@ class AesGcmCipherProviderTest {
     @Test
     fun decrypt_withTamperedCipherText_shouldThrowAEADBadTagException() {
         val aad = "TamperAAD".toByteArray()
-        val provider = AesGcmCipherProvider.create("tamper-alias", aad)
+        val provider = AesGcmCipherProvider.create(aad)
         val plaintext = "Don't tamper me".toByteArray()
         val encrypted = provider.encrypt(plaintext)
 

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
@@ -35,10 +35,9 @@ class ChaCha20CipherProviderTest {
     private val keyProvider = SecureRandomKeyProvider.create(
         context = context,
         fileName = "test-key",
-        keyAlias = "test-key",
         keySize = 32,
         algorithm = "ChaCha20",
-        cipherProvider = AesGcmCipherProvider.create("test-gcm-alias", "test".toByteArray()),
+        cipherProvider = AesGcmCipherProvider.create("test".toByteArray()),
     )
 
     @After

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
@@ -37,11 +37,10 @@ class SecureRandomKeyProviderTest {
 
     @Before
     fun setUp() {
-        val cipher = AesGcmCipherProvider.create("test-gcm-alias", "test".toByteArray())
+        val cipher = AesGcmCipherProvider.create("test".toByteArray())
         provider = SecureRandomKeyProvider.create(
             context = context,
             fileName = "test_key",
-            keyAlias = "test_key",
             keySize = 32,
             algorithm = "ChaCha20",
             cipherProvider = cipher,
@@ -70,10 +69,9 @@ class SecureRandomKeyProviderTest {
         val newInstance = SecureRandomKeyProvider.create(
             context = context,
             fileName = "test_key",
-            keyAlias = "test_key",
             keySize = 32,
             algorithm = "ChaCha20",
-            cipherProvider = AesGcmCipherProvider.create("test-gcm-alias", "test".toByteArray()),
+            cipherProvider = AesGcmCipherProvider.create("test".toByteArray()),
         )
         val reloaded = newInstance.getOrCreateKey().encoded
         assertContentEquals(original, reloaded)

--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -204,53 +204,6 @@ public class SafeBox private constructor(private val engine: SafeBoxEngine) : Sh
             val engine = SafeBoxEngine.create(
                 context = context,
                 fileName = fileName,
-                keyAlias = DEFAULT_KEY_ALIAS,
-                valueKeyStoreAlias = DEFAULT_VALUE_KEYSTORE_ALIAS,
-                ioDispatcher = ioDispatcher,
-                stateListener = stateListener,
-            )
-            return createInternal(fileName, stateListener, engine)
-        }
-
-        /**
-         * **Deprecation:** SafeBox now manages Keystore aliases internally for safety and
-         * consistency. `keyAlias` and `valueKeyStoreAlias` are planned for removal in v1.4.
-         *
-         * Creates a [SafeBox] instance with secure defaults:
-         * - Keys are deterministically encrypted using [ChaCha20CipherProvider].
-         * - Values are encrypted with the same ChaCha20 key, using a randomized IV per encryption.
-         * - The ChaCha20 secret is encrypted with AES-GCM via [SecureRandomKeyProvider].
-         *
-         * This method is idempotent per [fileName]. Repeated calls return the existing instance.
-         * If [stateListener] is non-null, it replaces the current listener. All other parameters
-         * are ignored when the instance already exists.
-         *
-         * @param context The application context
-         * @param fileName The name of the backing file used for persistence
-         * @param keyAlias The identifier for storing the key (used to locate its encrypted form)
-         * @param valueKeyStoreAlias The Android Keystore alias used for AES-GCM key generation
-         * @param ioDispatcher The dispatcher used for I/O operations (default: [Dispatchers.IO])
-         * @param stateListener The listener to observe instance-bound state transitions
-         *
-         * @return A fully configured [SafeBox] instance
-         */
-        @Deprecated("Aliases are ignored. Use the overload without aliases.")
-        @JvmOverloads
-        @JvmStatic
-        @Throws(IllegalStateException::class)
-        public fun create(
-            context: Context,
-            fileName: String,
-            keyAlias: String,
-            valueKeyStoreAlias: String,
-            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-            stateListener: SafeBoxStateListener? = null,
-        ): SafeBox {
-            val engine = SafeBoxEngine.create(
-                context = context,
-                fileName = fileName,
-                keyAlias = keyAlias,
-                valueKeyStoreAlias = valueKeyStoreAlias,
                 ioDispatcher = ioDispatcher,
                 stateListener = stateListener,
             )

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
@@ -21,6 +21,7 @@ import android.security.keystore.KeyProperties.ENCRYPTION_PADDING_NONE
 import android.security.keystore.KeyProperties.KEY_ALGORITHM_AES
 import android.security.keystore.KeyProperties.PURPOSE_DECRYPT
 import android.security.keystore.KeyProperties.PURPOSE_ENCRYPT
+import com.harrytmthy.safebox.SafeBox.Companion.DEFAULT_VALUE_KEYSTORE_ALIAS
 import com.harrytmthy.safebox.extensions.requireAes
 import com.harrytmthy.safebox.keystore.AndroidKeyStoreKeyProvider
 import com.harrytmthy.safebox.keystore.KeyProvider
@@ -79,9 +80,9 @@ internal class AesGcmCipherProvider private constructor(
 
         private const val GCM_TAG_LENGTH_BITS = 128
 
-        internal fun create(alias: String, aad: ByteArray?): CipherProvider {
+        internal fun create(aad: ByteArray?): CipherProvider {
             val provider = AndroidKeyStoreKeyProvider(
-                alias = alias,
+                alias = DEFAULT_VALUE_KEYSTORE_ALIAS,
                 algorithm = KEY_ALGORITHM_AES,
                 purposes = PURPOSE_ENCRYPT or PURPOSE_DECRYPT,
                 parameterSpecBuilder = {

--- a/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
@@ -327,19 +327,13 @@ internal class SafeBoxEngine private constructor(
         fun create(
             context: Context,
             fileName: String,
-            keyAlias: String,
-            valueKeyStoreAlias: String,
             ioDispatcher: CoroutineDispatcher,
             stateListener: SafeBoxStateListener?,
         ): SafeBoxEngine {
-            val aesGcmCipherProvider = AesGcmCipherProvider.create(
-                alias = valueKeyStoreAlias,
-                aad = fileName.toByteArray(),
-            )
+            val aesGcmCipherProvider = AesGcmCipherProvider.create(aad = fileName.toByteArray())
             val keyProvider = SecureRandomKeyProvider.create(
                 context = context,
                 fileName = fileName,
-                keyAlias = keyAlias,
                 keySize = ChaCha20CipherProvider.KEY_SIZE,
                 algorithm = ChaCha20CipherProvider.ALGORITHM,
                 cipherProvider = aesGcmCipherProvider,

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProvider.kt
@@ -140,21 +140,16 @@ internal class SecureRandomKeyProvider private constructor(
         internal fun create(
             context: Context,
             fileName: String,
-            keyAlias: String,
             keySize: Int,
             algorithm: String,
             cipherProvider: CipherProvider,
         ): SecureRandomKeyProvider {
-            val file = getEncryptedKeyFile(context, fileName, keyAlias)
+            val file = getEncryptedKeyFile(context, fileName)
             return SecureRandomKeyProvider(file, keySize, algorithm, cipherProvider)
         }
 
-        private fun getEncryptedKeyFile(
-            context: Context,
-            fileName: String,
-            keyAlias: String,
-        ): File {
-            val oldDestination = File(context.noBackupFilesDir, "$keyAlias.bin")
+        private fun getEncryptedKeyFile(context: Context, fileName: String): File {
+            val oldDestination = File(context.noBackupFilesDir, "SafeBoxKey.bin")
             val newDestination = File(context.noBackupFilesDir, "$fileName.key.bin")
             if (newDestination.exists() && newDestination.length() > 0L) {
                 return newDestination


### PR DESCRIPTION
### Summary
Drop deprecated alias parameters from public APIs and wire SafeBox to the alias-less crypto factory. This finalizes the direction from #103 and fits the split from #110.

### Implementation Details
- Remove `SafeBox.create(context, fileName, keyAlias, valueKeyStoreAlias, ...)`.
- Preserve internal migration from legacy alias files/keystore.
- Update unit/instrumented tests and KDoc.

Closes #111