### PR TITLE
refactor: Clean up alias-based fields leftovers and KEK migration

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProviderTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProviderTest.kt
@@ -36,7 +36,6 @@ class AndroidKeyStoreKeyProviderTest {
     @Test
     fun getOrCreateKey_withAes_shouldReturnValidAesKey() {
         val keyProvider = AndroidKeyStoreKeyProvider(
-            alias = "TestAlias",
             algorithm = KEY_ALGORITHM_AES,
             purposes = PURPOSE_ENCRYPT or PURPOSE_DECRYPT,
             parameterSpecBuilder = {
@@ -53,7 +52,6 @@ class AndroidKeyStoreKeyProviderTest {
     @Test
     fun getOrCreateKey_withAes_shouldReturnTheSameKeyAcrossInvocations() {
         val keyProvider = AndroidKeyStoreKeyProvider(
-            alias = "TestAlias",
             algorithm = KEY_ALGORITHM_AES,
             purposes = PURPOSE_ENCRYPT or PURPOSE_DECRYPT,
             parameterSpecBuilder = {
@@ -71,7 +69,6 @@ class AndroidKeyStoreKeyProviderTest {
     @Test
     fun getOrCreateKey_withHmac_shouldReturnValidAesKey() {
         val keyProvider = AndroidKeyStoreKeyProvider(
-            alias = "TestAlias",
             algorithm = KEY_ALGORITHM_HMAC_SHA256,
             purposes = PURPOSE_SIGN or PURPOSE_VERIFY,
             parameterSpecBuilder = { setDigests(DIGEST_SHA256) },

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/AesGcmCipherProvider.kt
@@ -21,7 +21,6 @@ import android.security.keystore.KeyProperties.ENCRYPTION_PADDING_NONE
 import android.security.keystore.KeyProperties.KEY_ALGORITHM_AES
 import android.security.keystore.KeyProperties.PURPOSE_DECRYPT
 import android.security.keystore.KeyProperties.PURPOSE_ENCRYPT
-import com.harrytmthy.safebox.SafeBox.Companion.DEFAULT_VALUE_KEYSTORE_ALIAS
 import com.harrytmthy.safebox.extensions.requireAes
 import com.harrytmthy.safebox.keystore.AndroidKeyStoreKeyProvider
 import com.harrytmthy.safebox.keystore.KeyProvider
@@ -66,12 +65,6 @@ internal class AesGcmCipherProvider private constructor(
         return cipher.doFinal(actualData)
     }
 
-    override fun rotateKey() {
-        keyProvider.rotateKey()
-    }
-
-    override fun shouldRotateKey(): Boolean = keyProvider.shouldRotateKey()
-
     internal companion object {
 
         private const val TRANSFORMATION = "AES/GCM/NoPadding"
@@ -82,7 +75,6 @@ internal class AesGcmCipherProvider private constructor(
 
         internal fun create(aad: ByteArray?): CipherProvider {
             val provider = AndroidKeyStoreKeyProvider(
-                alias = DEFAULT_VALUE_KEYSTORE_ALIAS,
                 algorithm = KEY_ALGORITHM_AES,
                 purposes = PURPOSE_ENCRYPT or PURPOSE_DECRYPT,
                 parameterSpecBuilder = {

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -78,10 +78,6 @@ internal class ChaCha20CipherProvider(
             plaintext
         }
 
-    override fun destroyKey() {
-        keyProvider.destroyKey()
-    }
-
     internal companion object {
         internal const val ALGORITHM = "ChaCha20"
         internal const val KEY_SIZE = 32

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
@@ -37,24 +37,4 @@ public interface CipherProvider {
      * Decrypts the given [ciphertext] using the provided secret key.
      */
     fun decrypt(ciphertext: ByteArray): ByteArray
-
-    /**
-     * Triggers key rotation by replacing the existing key with a new one.
-     */
-    fun rotateKey() = Unit
-
-    /**
-     * Decides whether or not key rotation must be done.
-     *
-     * @return `true` if key rotation must be done. `false` otherwise.
-     */
-    fun shouldRotateKey(): Boolean = false
-
-    /**
-     * Destroys any associated cryptographic key material. This method is called when SafeBox
-     * is permanently closed to prevent key leakage from memory.
-     *
-     * Default implementation is a no-op.
-     */
-    fun destroyKey() = Unit
 }

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProvider.kt
@@ -45,12 +45,10 @@ import javax.crypto.SecretKey
  * }
  * ```
  *
- * @param alias The key alias under which the key is stored in AndroidKeyStore.
  * @param purposes The cryptographic purposes (e.g. [PURPOSE_ENCRYPT], [PURPOSE_SIGN]).
  * @param parameterSpecBuilder Lambda that configures the [KeyGenParameterSpec.Builder].
  */
 internal class AndroidKeyStoreKeyProvider(
-    private val alias: String,
     algorithm: String,
     purposes: Int,
     parameterSpecBuilder: KeyGenParameterSpec.Builder.() -> Unit,
@@ -73,32 +71,7 @@ internal class AndroidKeyStoreKeyProvider(
         }
     }
 
-    private val aliasKey by lazy {
-        if (keyStore.containsAlias(alias)) {
-            val entry = keyStore.getEntry(alias, null) as SecretKeyEntry
-            entry.secretKey
-        } else {
-            defaultKey
-        }
-    }
-
-    override fun getOrCreateKey(): SecretKey =
-        if (keyStore.containsAlias(DEFAULT_VALUE_KEYSTORE_ALIAS)) {
-            defaultKey
-        } else {
-            aliasKey
-        }
-
-    override fun rotateKey() {
-        defaultKey // Triggers lazy-init
-        keyStore.deleteEntry(alias)
-    }
-
-    override fun shouldRotateKey(): Boolean {
-        val defaultExists = keyStore.containsAlias(DEFAULT_VALUE_KEYSTORE_ALIAS)
-        val legacyExists = alias != DEFAULT_VALUE_KEYSTORE_ALIAS && keyStore.containsAlias(alias)
-        return !defaultExists || legacyExists
-    }
+    override fun getOrCreateKey(): SecretKey = defaultKey
 
     private companion object {
         const val ANDROID_KEYSTORE = "AndroidKeyStore"

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
@@ -34,22 +34,4 @@ internal interface KeyProvider {
      * @return A non-null [SecretKey] instance.
      */
     fun getOrCreateKey(): SecretKey
-
-    /**
-     * Triggers key rotation by replacing the existing key with a new one.
-     */
-    fun rotateKey() = Unit
-
-    /**
-     * Decides whether or not key rotation must be done.
-     *
-     * @return `true` if key rotation must be done. `false` otherwise.
-     */
-    fun shouldRotateKey(): Boolean = false
-
-    /**
-     * Destroys any in-memory key material held by the implementation.
-     * This is typically used during shutdown to ensure sensitive key data is wiped from memory.
-     */
-    fun destroyKey() = Unit
 }


### PR DESCRIPTION
### Summary
Finish removing alias-based and rotation-specific code paths and simplify the crypto/keystore surface to match the new alias-less design.

Closes #111