### PR TITLE
perf(crypto): Remove process-wide ChaCha20 lock & use separate DEK providers

### DIFF
--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -41,6 +41,8 @@ internal class ChaCha20CipherProvider(
     private val deterministic: Boolean,
 ) : CipherProvider {
 
+    private val cipherLock = Any()
+
     private val cipher by lazy {
         try {
             Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
@@ -84,6 +86,5 @@ internal class ChaCha20CipherProvider(
         internal const val TRANSFORMATION = "ChaCha20-Poly1305"
         private const val IV_SIZE = 12
         private const val MAC_SIZE_BITS = 128
-        private val cipherLock = Any()
     }
 }

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/factory/SafeBoxCryptoFactory.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/factory/SafeBoxCryptoFactory.kt
@@ -50,15 +50,22 @@ object SafeBoxCryptoFactory {
         fileName: String,
     ): Pair<CipherProvider, CipherProvider> {
         val aesGcmCipherProvider = AesGcmCipherProvider.create(aad = fileName.toByteArray())
-        val keyProvider = SecureRandomKeyProvider.create(
+        val keyCipherKeyProvider = SecureRandomKeyProvider.create(
             context = context,
             fileName = fileName,
             keySize = ChaCha20CipherProvider.KEY_SIZE,
             algorithm = ChaCha20CipherProvider.ALGORITHM,
             cipherProvider = aesGcmCipherProvider,
         )
-        val keyCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = true)
-        val valueCipherProvider = ChaCha20CipherProvider(keyProvider, deterministic = false)
-        return keyCipherProvider to valueCipherProvider
+        val valueCipherKeyProvider = SecureRandomKeyProvider.create(
+            context = context,
+            fileName = fileName,
+            keySize = ChaCha20CipherProvider.KEY_SIZE,
+            algorithm = ChaCha20CipherProvider.ALGORITHM,
+            cipherProvider = aesGcmCipherProvider,
+        )
+        val keyCipher = ChaCha20CipherProvider(keyCipherKeyProvider, deterministic = true)
+        val valueCipher = ChaCha20CipherProvider(valueCipherKeyProvider, deterministic = false)
+        return keyCipher to valueCipher
     }
 }


### PR DESCRIPTION
### Summary
Use two DEK providers (same file) so each `ChaCha20CipherProvider` holds its own `SafeSecretKey`. Drop the process-wide cipher lock and keep an instance lock per provider to remain thread-safe without cross-cipher serialization.

### Implementation Details
- `SafeBoxCryptoFactory.createChaCha20Providers(context, fileName)` now creates two `SecureRandomKeyProvider` instances targeting the same DEK file and passes each to its own `ChaCha20CipherProvider`.
- `ChaCha20CipherProvider` now uses per instance lock.

Closes #0