### PR TITLE
fix(keystore): Ensure single DEK per file via lazy on-disk init & per-file lock

### DIFF
--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProvider.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/keystore/AndroidKeyStoreKeyProvider.kt
@@ -35,7 +35,7 @@ import javax.crypto.SecretKey
  * ## Usage Example
  * ```
  * val aesKeyProvider = AndroidKeyStoreKeyProvider(
- *     alias = "aes-key",
+ *     algorithm = "AES",
  *     purposes = PURPOSE_ENCRYPT or PURPOSE_DECRYPT
  * ) {
  *     setBlockModes("GCM")

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -163,6 +163,24 @@ class SafeBoxTest {
     }
 
     @Test
+    fun getInt_shouldReturnPersistedValue() {
+        safeBox = createSafeBox()
+        var prefs = createSafeBox(legacyAlias)
+        safeBox.edit().putInt("key", 1).commit()
+        prefs.edit().putInt("key", 2).apply()
+        engines[fileName]?.closeBlobStoreChannel()
+        engines[legacyAlias]?.closeBlobStoreChannel()
+        SafeBox.instances.remove(fileName)
+        SafeBox.instances.remove(legacyAlias)
+
+        safeBox = createSafeBox()
+        prefs = createSafeBox(legacyAlias)
+
+        assertEquals(1, safeBox.getInt("key", -1))
+        assertEquals(2, prefs.getInt("key", -1))
+    }
+
+    @Test
     fun commit_shouldWaitForApplyCompletion() {
         safeBox = createSafeBox()
         safeBox.edit().apply {

--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/migration/SafeBoxMigrationHelperTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/migration/SafeBoxMigrationHelperTest.kt
@@ -26,6 +26,7 @@ import com.harrytmthy.safebox.SafeBox
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.runner.RunWith
+import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -65,7 +66,9 @@ class SafeBoxMigrationHelperTest {
             .clear()
             .commit()
         context.deleteSharedPreferences(fileEsp)
-        context.deleteFile("$fileSafeBox.bin")
+        File(context.noBackupFilesDir, "$fileSafeBox.bin").delete()
+        File(context.noBackupFilesDir, "$fileSafeBox.key.bin").delete()
+        SafeBox.instances.remove(fileSafeBox)
     }
 
     @Test


### PR DESCRIPTION
### Summary
Initialize the DEK from disk lazily and guard the first write with a **per-file (by `fileName`) lock** so both providers resolve to the same key. Prevents divergent DEKs and preserves persistence across restarts.

Closes #119