### PR TITLE
feat(crypto): Add SafeBoxCrypto and decouple ChaCha20Cipher from its CipherProvider

### DIFF
--- a/safebox-crypto/build.gradle.kts
+++ b/safebox-crypto/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.bouncy.castle.provider)
 
+    testImplementation(libs.kotlin.test)
+
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.kotlin.test)

--- a/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/SafeBoxCryptoTest.kt
+++ b/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/SafeBoxCryptoTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class SafeBoxCryptoTest {
+
+    @Test
+    fun decrypt_shouldReturnOriginalText() {
+        val originalText = "SafeBoxCrypto works! 😂"
+        val secret = SafeBoxCrypto.createSecret()
+        val encryptedText = SafeBoxCrypto.encrypt(originalText, secret)
+
+        val text = SafeBoxCrypto.decrypt(encryptedText, secret)
+
+        assertEquals(originalText, text)
+    }
+
+    @Test
+    fun decryptOrNull_shouldReturnOriginalText() {
+        val originalText = "SafeBoxCrypto works! 😂"
+        val secret = SafeBoxCrypto.createSecret()
+        val encryptedText = SafeBoxCrypto.encryptOrNull(originalText, secret).orEmpty()
+
+        val text = SafeBoxCrypto.decryptOrNull(encryptedText, secret)
+
+        assertEquals(originalText, text)
+    }
+}

--- a/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
+++ b/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProviderTest.kt
@@ -42,7 +42,7 @@ class ChaCha20CipherProviderTest {
 
     @After
     fun tearDown() {
-        File(context.noBackupFilesDir, "test-key.bin").delete()
+        File(context.noBackupFilesDir, "test-key.key.bin").delete()
     }
 
     @Test

--- a/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
+++ b/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/keystore/SecureRandomKeyProviderTest.kt
@@ -49,7 +49,7 @@ class SecureRandomKeyProviderTest {
 
     @After
     fun tearDown() {
-        File(context.noBackupFilesDir, "test_key.bin").delete()
+        File(context.noBackupFilesDir, "test_key.key.bin").delete()
         KeyStore.getInstance("AndroidKeyStore").apply {
             load(null)
             deleteEntry("test-gcm-alias")

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/SafeBoxCrypto.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/SafeBoxCrypto.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox
+
+import android.security.keystore.KeyProperties.DIGEST_SHA256
+import android.util.Base64
+import android.util.Log
+import com.harrytmthy.safebox.SafeBoxCrypto.decrypt
+import com.harrytmthy.safebox.SafeBoxCrypto.encrypt
+import com.harrytmthy.safebox.cryptography.ChaCha20Cipher
+import com.harrytmthy.safebox.cryptography.SafeCipher
+import com.harrytmthy.safebox.cryptography.SecureRandomProvider
+import com.harrytmthy.safebox.keystore.SafeSecretKey
+import java.security.GeneralSecurityException
+import java.security.MessageDigest
+import javax.crypto.SecretKey
+
+/**
+ * Simple crypto helper backed by ChaCha20-Poly1305.
+ *
+ * Inputs and outputs are strings:
+ *  - The secret is a 32-byte key encoded as Base64 URL safe.
+ *  - The ciphertext is also Base64 URL safe.
+ *  - Plaintext is encoded and decoded as UTF-8.
+ *
+ * Nonce strategy:
+ *  - Uses a random 12-byte nonce per call. Output framing is IV || ciphertext || tag.
+ *
+ * This helper does not use Android Keystore and does not persist keys.
+ * Keep the secret safe and supply the same secret to decrypt.
+ */
+object SafeBoxCrypto {
+
+    private val safeCipher: SafeCipher = ChaCha20Cipher(deterministic = false)
+
+    /**
+     * Creates a new 32-byte secret and returns it as Base64 URL safe.
+     *
+     * Anyone with this secret can decrypt data encrypted with it.
+     */
+    fun createSecret(): String {
+        val secretBytes = SecureRandomProvider.generate(ChaCha20Cipher.KEY_SIZE)
+        return encodeBase64(secretBytes)
+    }
+
+    /**
+     * Encrypts [text] using [secret].
+     *
+     * - [text] is encoded as UTF-8.
+     * - [secret] must be Base64 URL safe representing a 32-byte key.
+     *
+     * @return Ciphertext as Base64 URL safe.
+     * @throws GeneralSecurityException if encryption fails or inputs are malformed.
+     */
+    fun encrypt(text: String, secret: String): String {
+        val plaintext = text.toByteArray(Charsets.UTF_8)
+        val key = decodeBase64(secret).toSecretKey()
+        val ciphertext = safeCipher.encrypt(plaintext, key)
+        return encodeBase64(ciphertext)
+    }
+
+    /**
+     * Decrypts [encryptedText] using [secret] and returns the original UTF-8 string.
+     *
+     * - [encryptedText] must be Base64 URL safe.
+     * - [secret] must be Base64 URL safe representing a 32-byte key.
+     *
+     * @return The original text.
+     * @throws GeneralSecurityException if decryption fails or inputs are malformed.
+     */
+    fun decrypt(encryptedText: String, secret: String): String {
+        val ciphertext = decodeBase64(encryptedText)
+        val key = decodeBase64(secret).toSecretKey()
+        val plaintext = safeCipher.decrypt(ciphertext, key)
+        return plaintext.toString(Charsets.UTF_8)
+    }
+
+    /**
+     * Encrypts like [encrypt] but returns null on failure.
+     */
+    fun encryptOrNull(text: String, secret: String): String? =
+        try {
+            encrypt(text, secret)
+        } catch (e: GeneralSecurityException) {
+            Log.e("SafeBoxCrypto", "Failed to encrypt text.", e)
+            null
+        }
+
+    /**
+     * Decrypts like [decrypt] but returns null on failure.
+     */
+    fun decryptOrNull(text: String, secret: String): String? =
+        try {
+            decrypt(text, secret)
+        } catch (e: GeneralSecurityException) {
+            Log.e("SafeBoxCrypto", "Failed to decrypt text.", e)
+            null
+        }
+
+    private fun encodeBase64(bytes: ByteArray): String =
+        Base64.encodeToString(bytes, Base64.NO_WRAP or Base64.URL_SAFE)
+
+    private fun decodeBase64(value: String): ByteArray =
+        Base64.decode(value, Base64.NO_WRAP or Base64.URL_SAFE)
+
+    private fun ByteArray.toSecretKey(): SecretKey {
+        val mask = MessageDigest.getInstance(DIGEST_SHA256).digest(this)
+        return SafeSecretKey(
+            key = this,
+            mask = mask,
+            algorithm = ChaCha20Cipher.ALGORITHM,
+        )
+    }
+}

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.cryptography
+
+import android.annotation.SuppressLint
+import android.security.keystore.KeyProperties.DIGEST_SHA256
+import com.harrytmthy.safebox.keystore.SafeSecretKey
+import org.bouncycastle.jcajce.spec.AEADParameterSpec
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.GeneralSecurityException
+import java.security.MessageDigest
+import java.security.Security
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+
+/**
+ * A ChaCha20-Poly1305 [SafeCipher] that uses BouncyCastle.
+ *
+ * IV strategy:
+ *  - If `deterministic == true`, IV = SHA-256(plaintext). This intentionally leaks plaintext
+ *    equality and is only appropriate for encrypting *keys* (e.g. preference keys).
+ *  - Otherwise IV is random per call (recommended for values).
+ *
+ * **Note:** Android ships an outdated BouncyCastle. Newer releases include modern algorithms.
+ * Suppressing the deprecation warning is required to reference the provider name.
+ *
+ * **Output framing:** IV (12 bytes) || ciphertext || tag.
+ */
+@SuppressLint("DeprecatedProvider")
+internal class ChaCha20Cipher(private val deterministic: Boolean) : SafeCipher {
+
+    private val cipherLock = Any()
+
+    private val cipher by lazy {
+        try {
+            Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
+        } catch (_: GeneralSecurityException) {
+            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+            Security.addProvider(BouncyCastleProvider())
+            Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
+        }
+    }
+
+    override fun encrypt(plaintext: ByteArray, key: SecretKey): ByteArray =
+        synchronized(cipherLock) {
+            val iv = if (deterministic) {
+                MessageDigest.getInstance(DIGEST_SHA256).digest(plaintext).copyOf(IV_SIZE)
+            } else {
+                SecureRandomProvider.generate(IV_SIZE)
+            }
+            val paramSpec = AEADParameterSpec(iv, MAC_SIZE_BITS)
+            cipher.init(Cipher.ENCRYPT_MODE, key, paramSpec)
+            val encrypted = cipher.doFinal(plaintext)
+            (key as? SafeSecretKey)?.releaseHeapCopy()
+            iv + encrypted
+        }
+
+    override fun decrypt(ciphertext: ByteArray, key: SecretKey): ByteArray =
+        synchronized(cipherLock) {
+            val iv = ciphertext.copyOfRange(0, IV_SIZE)
+            val actual = ciphertext.copyOfRange(IV_SIZE, ciphertext.size)
+            val paramSpec = AEADParameterSpec(iv, MAC_SIZE_BITS)
+            cipher.init(Cipher.DECRYPT_MODE, key, paramSpec)
+            val plaintext = cipher.doFinal(actual)
+            (key as? SafeSecretKey)?.releaseHeapCopy()
+            plaintext
+        }
+
+    internal companion object {
+        internal const val ALGORITHM = "ChaCha20"
+        internal const val KEY_SIZE = 32
+        internal const val TRANSFORMATION = "ChaCha20-Poly1305"
+        private const val IV_SIZE = 12
+        private const val MAC_SIZE_BITS = 128
+    }
+}

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/SafeCipher.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/SafeCipher.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.cryptography
+
+import javax.crypto.SecretKey
+
+/**
+ * Low-level cipher primitive that operates with a caller-supplied [SecretKey].
+ *
+ * This interface **does not manage keys**. Callers pass the exact key to use on each call.
+ * Implementations must define:
+ *  - IV/nonce strategy (e.g. random vs deterministic)
+ *  - Output framing (e.g. IV || ciphertext || tag)
+ */
+internal interface SafeCipher {
+
+    /**
+     * Encrypts [plaintext] using the provided [key].
+     */
+    fun encrypt(plaintext: ByteArray, key: SecretKey): ByteArray
+
+    /**
+     * Decrypts [ciphertext] using the provided [key].
+     */
+    fun decrypt(ciphertext: ByteArray, key: SecretKey): ByteArray
+}

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/factory/SafeBoxCryptoFactory.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/factory/SafeBoxCryptoFactory.kt
@@ -18,6 +18,7 @@ package com.harrytmthy.safebox.factory
 
 import android.content.Context
 import com.harrytmthy.safebox.cryptography.AesGcmCipherProvider
+import com.harrytmthy.safebox.cryptography.ChaCha20Cipher
 import com.harrytmthy.safebox.cryptography.ChaCha20CipherProvider
 import com.harrytmthy.safebox.cryptography.CipherProvider
 import com.harrytmthy.safebox.keystore.SecureRandomKeyProvider
@@ -53,15 +54,15 @@ object SafeBoxCryptoFactory {
         val keyCipherKeyProvider = SecureRandomKeyProvider.create(
             context = context,
             fileName = fileName,
-            keySize = ChaCha20CipherProvider.KEY_SIZE,
-            algorithm = ChaCha20CipherProvider.ALGORITHM,
+            keySize = ChaCha20Cipher.KEY_SIZE,
+            algorithm = ChaCha20Cipher.ALGORITHM,
             cipherProvider = aesGcmCipherProvider,
         )
         val valueCipherKeyProvider = SecureRandomKeyProvider.create(
             context = context,
             fileName = fileName,
-            keySize = ChaCha20CipherProvider.KEY_SIZE,
-            algorithm = ChaCha20CipherProvider.ALGORITHM,
+            keySize = ChaCha20Cipher.KEY_SIZE,
+            algorithm = ChaCha20Cipher.ALGORITHM,
             cipherProvider = aesGcmCipherProvider,
         )
         val keyCipher = ChaCha20CipherProvider(keyCipherKeyProvider, deterministic = true)


### PR DESCRIPTION
### Summary
Add `SafeBoxCrypto` (string-to-string helper) and decouple ChaCha20 from `KeyProvider` via a new `SafeCipher` interface.

Closes #121