### PR TITLE
release: v1.3.0-alpha01 with crypto module, API cleanup, and perf gains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0-alpha01] - 2025-09-08
+
+### Added
+- **Crypto-only module:** New `:safebox-crypto` published as a standalone artifact. ([#110](https://github.com/harrytmthy/safebox/issues/110))
+- **SafeBoxCrypto helper:** Simple string-in, string-out ChaCha20-Poly1305 helper with URL-safe Base64. ([#121](https://github.com/harrytmthy/safebox/issues/121))
+
+### Changed
+- **Public API cleanup:** Removed alias-based params from public APIs. Creation now manages aliases internally. ([#111](https://github.com/harrytmthy/safebox/issues/111))
+
+### Performance
+- **Smaller dependency footprint:** Switched to `bcprov-jdk15on` and replaced blanket keeps with minimal rules. Minified apps are ≈9.5× smaller than before for SafeBox impact. ([#115](https://github.com/harrytmthy/safebox/issues/115))
+- **Lower contention:** Isolated ChaCha providers so key and value ciphers do not block each other. ([#117](https://github.com/harrytmthy/safebox/issues/117))
+
+### Fixed
+- **R8 errors:** Removed LDAP/X.509 pulls and missing-class warnings while keeping ChaCha20-Poly1305 intact. ([#115](https://github.com/harrytmthy/safebox/issues/115))
+- **Single DEK per file:** Ensure both ciphers for a given file resolve the same DEK with per-file locking and lazy load. ([#119](https://github.com/harrytmthy/safebox/issues/119))
+- **Listener parity:** Notifications aligned with `SharedPreferences` semantics. ([#102](https://github.com/harrytmthy/safebox/issues/102))
+
+### CI
+- **Faster builds:** Remove duplicate Gradle caching and scope concurrency per workflow. ([#108](https://github.com/harrytmthy/safebox/issues/108))
+
+### Breaking changes
+- **Alias-based creation removed:** If you previously used a custom `valueKeyStoreAlias`, reads may fail on upgrade. Migrate data to the default alias before adopting this version. ([#103](https://github.com/harrytmthy/safebox/issues/103), [#111](https://github.com/harrytmthy/safebox/issues/111))
+
 ## [1.2.0] - 2025-09-01
 
 ### Added

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,41 @@
+# Observing State Changes
+
+You can observe SafeBox lifecycle state transitions (`STARTING`, `WRITING`, `IDLE`) in two ways.
+
+## 1. Instance-bound listener
+
+```kotlin
+val safeBox = SafeBox.create(
+    context = context,
+    fileName = PREF_FILE_NAME,
+    stateListener = SafeBoxStateListener { state ->
+        when (state) {
+            SafeBoxState.STARTING -> trackStart()    // Loading from disk
+            SafeBoxState.IDLE     -> trackIdle()     // No active persistence
+            SafeBoxState.WRITING  -> trackWrite()    // Persisting to disk
+        }
+    }
+)
+```
+
+## 2. Global observer
+
+```kotlin
+val listener = SafeBoxStateListener { state ->
+    when (state) {
+        SafeBoxState.STARTING -> onStart()
+        SafeBoxState.IDLE     -> onIdle()
+        SafeBoxState.WRITING  -> onWrite()
+    }
+}
+SafeBoxGlobalStateObserver.addListener(PREF_FILE_NAME, listener)
+
+// later
+SafeBoxGlobalStateObserver.removeListener(PREF_FILE_NAME, listener)
+```
+
+You can also query the current state:
+
+```kotlin
+val state = SafeBoxGlobalStateObserver.getCurrentState(PREF_FILE_NAME)
+```

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.2.0"
+version = "1.3.0-alpha01"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
This release introduces `v1.3.0-alpha01`, focusing on a standalone crypto module, API simplification, and size/perf wins.

### Highlights
- **New `:safebox-crypto` module** for reuse beyond preferences. ([#110])
- **SafeBoxCrypto helper** with URL-safe Base64 strings. ([#121])
- **API cleanup** by removing alias-based params from public APIs. ([#111])
- **APK size** cut by replacing `bcprov-jdk15to18` and using targeted keep rules. ([#115])
- **Lower contention** by isolating ChaCha providers and ensuring one DEK per file via per-file locks. ([#117], [#119])
- **CI** improvements by streamlining Gradle caching and concurrency. ([#108])

### Breaking changes
- Removed alias-based creation. If you relied on custom `valueKeyStoreAlias`, migrate data first. ([#103], [#111])