### PR TITLE
docs(state): Deprecate state, state listener, and global state listener

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserver.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserver.kt
@@ -21,11 +21,15 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
+ * **Deprecated:** SafeBox is designed to be a drop-in replacement for EncryptedSharedPreferences.
+ * State updates goes out-of-scope as SafeBox can no longer be closed.
+ *
  * Public observer interface for monitoring SafeBox state changes.
  *
  * Allows clients to observe SafeBox's lifecycle state transitions for a given file name,
  * enabling safer orchestration in multi-screen or asynchronous apps.
  */
+@Deprecated(message = "SafeBoxGlobalStateObserver is deprecated and will be removed in v1.4.")
 public object SafeBoxGlobalStateObserver {
 
     private val stateHolder = ConcurrentHashMap<String, SafeBoxState>()

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
@@ -19,12 +19,16 @@ package com.harrytmthy.safebox.state
 import com.harrytmthy.safebox.SafeBox
 
 /**
+ * **Deprecated:** SafeBox is designed to be a drop-in replacement for EncryptedSharedPreferences.
+ * State updates goes out-of-scope as SafeBox can no longer be closed.
+ *
  * Lifecycle state of a [SafeBox] instance.
  *
  * Emitted to [SafeBoxStateListener] for visibility during async work.
  *
  * @see SafeBoxStateListener
  */
+@Deprecated(message = "SafeBoxState is deprecated and will be removed in v1.4.")
 public enum class SafeBoxState {
 
     /**

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateListener.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateListener.kt
@@ -17,6 +17,9 @@
 package com.harrytmthy.safebox.state
 
 /**
+ * **Deprecated:** SafeBox is designed to be a drop-in replacement for EncryptedSharedPreferences.
+ * State updates goes out-of-scope as SafeBox can no longer be closed.
+ *
  * A listener interface for observing [SafeBoxState] changes tied to a specific SafeBox file.
  *
  * This is typically used in non-singleton SafeBox use cases (e.g. ViewModel-scoped),
@@ -24,6 +27,7 @@ package com.harrytmthy.safebox.state
  *
  * @see SafeBoxState
  */
+@Deprecated(message = "SafeBoxStateListener is deprecated and will be removed in v1.4.")
 public fun interface SafeBoxStateListener {
 
     /**


### PR DESCRIPTION
### Summary

- Marked `SafeBoxState`, `SafeBoxStateListener`, and `SafeBoxGlobalStateObserver` as `@Deprecated` with clear KDoc explaining why and removal target (v1.4).
- Kept behavior unchanged in 1.3.x (no runtime changes).
- Updated inline docs to recommend relying on `SharedPreferences` listener patterns and not on SafeBox-specific state.

Closes #125