### PR TITLE
feat: added API checks using kotlin-binary-compatibility-validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Clean project
         run: ./gradlew clean
 
+      - name: API check
+        run: ./gradlew apiCheck
+
       - name: Run lint
         run: ./gradlew lint
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,6 @@ plugins {
     alias(libs.plugins.compose) apply false
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.binary.compatibility) apply false
     alias(libs.plugins.maven.publish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ dokka = "2.0.0"
 junit4 = "4.13.2"
 kotlin = "2.2.10"
 kotlinxCoroutines = "1.10.2"
+kotlinBinaryCompatibility = "0.18.1"
 ksp = "2.2.10-2.0.2"
 mavenPublishPlugin = "0.32.0"
 protobuf = "4.29.2"
@@ -67,6 +68,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+kotlin-binary-compatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibility" }
 
 # Convention Plugins
 safebox-android-library = { id = "safebox.android.library" }

--- a/safebox-crypto/api/safebox-crypto.api
+++ b/safebox-crypto/api/safebox-crypto.api
@@ -1,0 +1,19 @@
+public final class com/harrytmthy/safebox/SafeBoxCrypto {
+	public static final field INSTANCE Lcom/harrytmthy/safebox/SafeBoxCrypto;
+	public final fun createSecret ()Ljava/lang/String;
+	public final fun decrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun decryptOrNull (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encryptOrNull (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/harrytmthy/safebox/cryptography/CipherProvider {
+	public abstract fun decrypt ([B)[B
+	public abstract fun encrypt ([B)[B
+}
+
+public final class com/harrytmthy/safebox/factory/SafeBoxCryptoFactory {
+	public static final field INSTANCE Lcom/harrytmthy/safebox/factory/SafeBoxCryptoFactory;
+	public final fun createChaCha20Providers (Landroid/content/Context;Ljava/lang/String;)Lkotlin/Pair;
+}
+

--- a/safebox-crypto/build.gradle.kts
+++ b/safebox-crypto/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     alias(libs.plugins.safebox.android.library)
     alias(libs.plugins.safebox.publishing)
+    alias(libs.plugins.kotlin.binary.compatibility)
 }
 
 android {

--- a/safebox/api/safebox.api
+++ b/safebox/api/safebox.api
@@ -1,0 +1,73 @@
+public final class com/harrytmthy/safebox/SafeBox : android/content/SharedPreferences {
+	public static final field Companion Lcom/harrytmthy/safebox/SafeBox$Companion;
+	public synthetic fun <init> (Lcom/harrytmthy/safebox/engine/SafeBoxEngine;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contains (Ljava/lang/String;)Z
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;)Lcom/harrytmthy/safebox/SafeBox;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/harrytmthy/safebox/SafeBox;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)Lcom/harrytmthy/safebox/SafeBox;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/harrytmthy/safebox/SafeBox;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)Lcom/harrytmthy/safebox/SafeBox;
+	public fun edit ()Landroid/content/SharedPreferences$Editor;
+	public static final fun get (Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+	public fun getAll ()Ljava/util/Map;
+	public fun getBoolean (Ljava/lang/String;Z)Z
+	public fun getFloat (Ljava/lang/String;F)F
+	public fun getInt (Ljava/lang/String;I)I
+	public fun getLong (Ljava/lang/String;J)J
+	public static final fun getOrNull (Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+	public fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun getStringSet (Ljava/lang/String;Ljava/util/Set;)Ljava/util/Set;
+	public fun registerOnSharedPreferenceChangeListener (Landroid/content/SharedPreferences$OnSharedPreferenceChangeListener;)V
+	public final fun setCastFailureStrategy (Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;)V
+	public fun unregisterOnSharedPreferenceChangeListener (Landroid/content/SharedPreferences$OnSharedPreferenceChangeListener;)V
+}
+
+public final class com/harrytmthy/safebox/SafeBox$Companion {
+	public final fun create (Landroid/content/Context;Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)Lcom/harrytmthy/safebox/SafeBox;
+	public static synthetic fun create$default (Lcom/harrytmthy/safebox/SafeBox$Companion;Landroid/content/Context;Ljava/lang/String;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lcom/harrytmthy/safebox/cryptography/CipherProvider;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;ILjava/lang/Object;)Lcom/harrytmthy/safebox/SafeBox;
+	public static synthetic fun create$default (Lcom/harrytmthy/safebox/SafeBox$Companion;Landroid/content/Context;Ljava/lang/String;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;ILjava/lang/Object;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun get (Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+	public final fun getOrNull (Ljava/lang/String;)Lcom/harrytmthy/safebox/SafeBox;
+}
+
+public final class com/harrytmthy/safebox/migration/SafeBoxMigrationHelper {
+	public static final field INSTANCE Lcom/harrytmthy/safebox/migration/SafeBoxMigrationHelper;
+	public static final fun migrate (Landroid/content/SharedPreferences;Landroid/content/SharedPreferences;)V
+	public static final fun migrate (Landroid/content/SharedPreferences;Landroid/content/SharedPreferences;Z)V
+	public static synthetic fun migrate$default (Landroid/content/SharedPreferences;Landroid/content/SharedPreferences;ZILjava/lang/Object;)V
+}
+
+public final class com/harrytmthy/safebox/state/SafeBoxGlobalStateObserver {
+	public static final field INSTANCE Lcom/harrytmthy/safebox/state/SafeBoxGlobalStateObserver;
+	public static final fun addListener (Ljava/lang/String;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)V
+	public static final fun getCurrentState (Ljava/lang/String;)Lcom/harrytmthy/safebox/state/SafeBoxState;
+	public static final fun removeListener (Ljava/lang/String;Lcom/harrytmthy/safebox/state/SafeBoxStateListener;)V
+}
+
+public final class com/harrytmthy/safebox/state/SafeBoxState : java/lang/Enum {
+	public static final field IDLE Lcom/harrytmthy/safebox/state/SafeBoxState;
+	public static final field STARTING Lcom/harrytmthy/safebox/state/SafeBoxState;
+	public static final field WRITING Lcom/harrytmthy/safebox/state/SafeBoxState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/harrytmthy/safebox/state/SafeBoxState;
+	public static fun values ()[Lcom/harrytmthy/safebox/state/SafeBoxState;
+}
+
+public abstract interface class com/harrytmthy/safebox/state/SafeBoxStateListener {
+	public abstract fun onStateChanged (Lcom/harrytmthy/safebox/state/SafeBoxState;)V
+}
+
+public final class com/harrytmthy/safebox/strategy/ValueFallbackStrategy : java/lang/Enum {
+	public static final field ERROR Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;
+	public static final field WARN Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;
+	public static fun values ()[Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;
+}
+

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     alias(libs.plugins.safebox.android.library)
     alias(libs.plugins.safebox.publishing)
+    alias(libs.plugins.kotlin.binary.compatibility)
 }
 
 android {


### PR DESCRIPTION
### Summary

This adds Kotlin Binary Compatibility Validator, it helps dump the binary API (based on Kotlin visibilities) and ensures public APIs don’t change in a way that breaks binary compatibility. Safebox doesn’t have this in place yet, so adding it will help safebox retain API consistency and guarantee backward and forward compatibility for future versions.

### Implementation Details

- [x] Added kotlin-binary-compatibility-validator
- [x] Generates dumps for safebox & safebox-crypto
- [x] Enabled :apiCheck in CI

Result:
```
Execution failed for task ':safebox:apiCheck'.
> API check failed for project safebox.
  --- /Users/bytedance/AndroidStudioProjects/safebox/safebox/api/safebox.api
  +++ /Users/bytedance/AndroidStudioProjects/safebox/safebox/build/api/safebox.api
  @@ -19,7 +19,7 @@
        public fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
        public fun getStringSet (Ljava/lang/String;Ljava/util/Set;)Ljava/util/Set;
        public fun registerOnSharedPreferenceChangeListener (Landroid/content/SharedPreferences$OnSharedPreferenceChangeListener;)V
  -     public final fun setCastFailureStrategy (Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;)V
  +     public final fun setCastFailureStrategiesss (Lcom/harrytmthy/safebox/strategy/ValueFallbackStrategy;)V
        public fun unregisterOnSharedPreferenceChangeListener (Landroid/content/SharedPreferences$OnSharedPreferenceChangeListener;)V
   }
   
  
  You can run :safebox:apiDump task to overwrite API declarations
```