### PR TITLE
refactor(engine): Improve recovery scheduling implementation

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
@@ -180,12 +180,12 @@ internal class SafeBoxBlobStore private constructor(private val file: File) {
      * @param encryptedKeys Vararg array of keys to delete.
      */
     internal suspend fun delete(vararg encryptedKeys: Bytes) {
+        if (encryptedKeys.isEmpty() || entryMetas.isEmpty()) {
+            return
+        }
         writeMutex.withLock {
             for (encryptedKey in encryptedKeys) {
-                if (!entryMetas.containsKey(encryptedKey)) {
-                    continue
-                }
-                val entry = entryMetas.getValue(encryptedKey)
+                val entry = entryMetas[encryptedKey] ?: continue
                 nextWritePositions[entry.page] = buffers[entry.page].shiftLeft(
                     currentTail = nextWritePositions[entry.page],
                     fromOffset = entry.offset + entry.size,


### PR DESCRIPTION
### Summary
Refactors the recovery replay loop to avoid nested coroutine lifetimes and adds partial-delete support in the recovery store so only successfully migrated records are compacted.

Closes #143