### PR TITLE
release: v1.3.0-alpha02 with segmented storage growth and recovery path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0-alpha02] - 2025-10-04
+
+### Added
+- **Segmented blob store growth:** Removes the 1 MiB ceiling by mapping multiple fixed-size pages and reusing freed space via compaction. ([#133](https://github.com/harrytmthy/safebox/issues/133))
+- **SafeBoxRecoveryBlobStore:** An append-only recovery file fallback used when a page cannot be allocated. Entries are replayed back into the main store with exponential backoff. ([#134](https://github.com/harrytmthy/safebox/issues/134))
+- **Kotlin BCV and API compatibility guard:** The binary validator is implemented at pipeline & pre-push check to prevent accidental public API breaks. ([#131](https://github.com/harrytmthy/safebox/issues/131))
+
+### Deprecated
+- **SafeBoxState and SafeBoxStateListener:** Removal planned in v1.4. ([#125](https://github.com/harrytmthy/safebox/issues/125))
+
 ## [1.3.0-alpha01] - 2025-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.3.0-alpha01")
+    implementation("io.github.harrytmthy:safebox:1.3.0-alpha02")
 
     // Optional: standalone crypto helper
-    implementation("io.github.harrytmthy:safebox-crypto:1.3.0-alpha01")
+    implementation("io.github.harrytmthy:safebox-crypto:1.3.0-alpha02")
 }
 ```
 

--- a/build-logic/convention/src/main/java/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/PublishingConventionPlugin.kt
@@ -25,7 +25,7 @@ class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             group = "io.github.harrytmthy"
-            version = "1.3.0-alpha01"
+            version = "1.3.0-alpha02"
 
             pluginManager.apply("org.jetbrains.dokka")
             pluginManager.apply("com.vanniktech.maven.publish")


### PR DESCRIPTION
# Release PR: v1.3.0-alpha02

This release introduces v1.3.0-alpha02 focusing on storage scalability and resilience under low-storage conditions.

### Highlights
- **Segmented storage growth:** Multi-page memory-mapped design removes the 1 MiB limit and reuses space via compaction. ([#133](https://github.com/harrytmthy/safebox/issues/133))
- **Recovery file fallback:** Adds `SafeBoxRecoveryBlobStore`, an append-only recovery journal used when page allocation fails. Automatically replays entries with exponential backoff once storage becomes available. ([#134](https://github.com/harrytmthy/safebox/issues/134))
- **Kotlin BCV and API guard:** Adds binary compatibility validation and pre-push API checks to prevent unintentional public API changes. ([#131](https://github.com/harrytmthy/safebox/issues/131))
- **Deprecation notice:** `SafeBoxState` and `SafeBoxStateListener` are deprecated and will be removed in v1.4. ([#125](https://github.com/harrytmthy/safebox/issues/125))