### PR TITLE
fix(crypto): Avoid replacing the platform BC provider

### DIFF
--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
@@ -23,7 +23,6 @@ import org.bouncycastle.jcajce.spec.AEADParameterSpec
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.GeneralSecurityException
 import java.security.MessageDigest
-import java.security.Security
 import javax.crypto.Cipher
 import javax.crypto.SecretKey
 
@@ -49,9 +48,7 @@ internal class ChaCha20Cipher(private val deterministic: Boolean) : SafeCipher {
         try {
             Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
         } catch (_: GeneralSecurityException) {
-            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-            Security.addProvider(BouncyCastleProvider())
-            Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
+            Cipher.getInstance(TRANSFORMATION, bundledBouncyCastleProvider)
         }
     }
 
@@ -86,5 +83,6 @@ internal class ChaCha20Cipher(private val deterministic: Boolean) : SafeCipher {
         internal const val TRANSFORMATION = "ChaCha20-Poly1305"
         private const val IV_SIZE = 12
         private const val MAC_SIZE_BITS = 128
+        private val bundledBouncyCastleProvider by lazy { BouncyCastleProvider() }
     }
 }


### PR DESCRIPTION
### Summary

Prevented the ChaCha20-Poly1305 fallback from replacing Android's process-wide BC provider.

### Implementation Details

Kept the existing platform provider lookup. When it cannot provide ChaCha20-Poly1305, the cipher now uses a lazily initialized private BouncyCastleProvider instance instead of modifying the global provider list.

Verified with a minified build on Android 9. The platform BC instance remained unchanged, KeyStore.BKS stayed available, and a default OkHttpClient initialized successfully after a SafeBox write.

Closes #172