### PR TITLE
release: v1.3.1 with Bouncy Castle provider isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2026-09-05
+
+### Fixed
+- **Bouncy Castle provider isolation:** Avoided replacing the process-wide `BC` provider during ChaCha20-Poly1305 initialization. SafeBox now uses its bundled provider privately as a fallback, preserving unrelated security services registered by the host application or platform. ([#172](https://github.com/harrytmthy/safebox/issues/172), [#175](https://github.com/harrytmthy/safebox/pull/175))
+
 ## [1.3.0] - 2025-10-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.3.0")
+    implementation("io.github.harrytmthy:safebox:1.3.1")
 
     // Optional: standalone crypto helper
-    implementation("io.github.harrytmthy:safebox-crypto:1.3.0")
+    implementation("io.github.harrytmthy:safebox-crypto:1.3.1")
 }
 ```
 

--- a/build-logic/convention/src/main/java/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/PublishingConventionPlugin.kt
@@ -25,7 +25,7 @@ class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             group = "io.github.harrytmthy"
-            version = "1.3.0"
+            version = "1.3.1"
 
             pluginManager.apply("org.jetbrains.dokka")
             pluginManager.apply("com.vanniktech.maven.publish")

--- a/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
+++ b/safebox-crypto/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20Cipher.kt
@@ -23,7 +23,6 @@ import org.bouncycastle.jcajce.spec.AEADParameterSpec
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.GeneralSecurityException
 import java.security.MessageDigest
-import java.security.Security
 import javax.crypto.Cipher
 import javax.crypto.SecretKey
 
@@ -49,9 +48,7 @@ internal class ChaCha20Cipher(private val deterministic: Boolean) : SafeCipher {
         try {
             Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
         } catch (_: GeneralSecurityException) {
-            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-            Security.addProvider(BouncyCastleProvider())
-            Cipher.getInstance(TRANSFORMATION, BouncyCastleProvider.PROVIDER_NAME)
+            Cipher.getInstance(TRANSFORMATION, bundledBouncyCastleProvider)
         }
     }
 
@@ -86,5 +83,6 @@ internal class ChaCha20Cipher(private val deterministic: Boolean) : SafeCipher {
         internal const val TRANSFORMATION = "ChaCha20-Poly1305"
         private const val IV_SIZE = 12
         private const val MAC_SIZE_BITS = 128
+        private val bundledBouncyCastleProvider by lazy { BouncyCastleProvider() }
     }
 }


### PR DESCRIPTION
### Summary

This PR finalizes the v1.3.1 release of SafeBox. This patch keeps the process-wide security provider registry unchanged by using the bundled Bouncy Castle provider privately for the ChaCha20-Poly1305 fallback.

### Highlights

#### Cryptography

- Uses the bundled Bouncy Castle provider directly when the registered provider cannot supply ChaCha20-Poly1305. ([[#172](https://github.com/harrytmthy/safebox/issues/172)](https://github.com/harrytmthy/safebox/issues/172), [[#175](https://github.com/harrytmthy/safebox/pull/175)](https://github.com/harrytmthy/safebox/pull/175))