### PR TITLE
feat(storage): Reclaim trailing empty pages

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/storage/SafeBoxBlobStoreTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/storage/SafeBoxBlobStoreTest.kt
@@ -49,6 +49,22 @@ class SafeBoxBlobStoreTest {
         File(context.noBackupFilesDir, "$fileName.bin").delete()
     }
 
+    /**
+     * Reopens the backing file in a fresh store and hands its persisted entries to [assertions].
+     *
+     * Reclamation bugs only show up here: [SafeBoxBlobStore.loadPersistedEntries] on the live
+     * store reads its own mapped buffers, so it cannot tell whether the truncated file on disk
+     * is still well-formed.
+     */
+    private suspend fun assertReopenedStore(assertions: (Map<Bytes, ByteArray>) -> Unit) {
+        val reopened = SafeBoxBlobStore.create(context, fileName)
+        try {
+            assertions(reopened.loadPersistedEntries())
+        } finally {
+            reopened.closeWhenIdle()
+        }
+    }
+
     @Test
     fun loadAll_shouldReturnWrittenEntries() = runTest {
         val firstKey = "alpha".toByteArray().toBytes()
@@ -319,6 +335,155 @@ class SafeBoxBlobStoreTest {
         val bin = File(context.noBackupFilesDir, "$fileName.bin")
         assertEquals(BUFFER_CAPACITY, bin.length())
         assertTrue(blobStore.entryMetas.isEmpty())
+    }
+
+    @Test
+    fun deleteFromLastPage_shouldReclaimEmptyPageAfterFlush() = runTest {
+        val keyA = "a".toByteArray().toBytes()
+        val keyB = "b".toByteArray().toBytes()
+        val valueA = ByteArray(BUFFER_CAPACITY.toInt() - (HEADER_SIZE + "a".length))
+        val valueB = byteArrayOf(0x01)
+        val regrownValueB = byteArrayOf(0x02)
+
+        blobStore.write(keyA, valueA, false)
+        blobStore.write(keyB, valueB, false)
+        blobStore.flushDirtyPages()
+
+        val bin = File(context.noBackupFilesDir, "$fileName.bin")
+        assertEquals(BUFFER_CAPACITY * 2, bin.length())
+
+        blobStore.delete(keyB, true)
+        blobStore.flushDirtyPages()
+
+        assertEquals(BUFFER_CAPACITY, bin.length())
+        assertContentEquals(valueA, blobStore.loadPersistedEntries()[keyA])
+        assertReopenedStore { entries ->
+            assertEquals(1, entries.size)
+            assertContentEquals(valueA, entries[keyA])
+        }
+
+        blobStore.write(keyB, regrownValueB, false)
+        blobStore.flushDirtyPages()
+
+        assertEquals(BUFFER_CAPACITY * 2, bin.length())
+        assertEquals(1, blobStore.entryMetas.getValue(keyB).page)
+        assertContentEquals(regrownValueB, blobStore.loadPersistedEntries()[keyB])
+        // Page 1 has now been mapped, dropped, truncated away and mapped again at the same
+        // offset while the first mapping may still be awaiting GC. Read it back from a fresh
+        // store to confirm the regrown page persists its own content and not the old bytes.
+        assertReopenedStore { entries ->
+            assertEquals(2, entries.size)
+            assertContentEquals(valueA, entries[keyA])
+            assertContentEquals(regrownValueB, entries[keyB])
+        }
+    }
+
+    @Test
+    fun overwriteFromLastPage_shouldReclaimEmptyPageAfterFlush() = runTest {
+        val fillerKey = "f".toByteArray().toBytes()
+        val movedKey = "m".toByteArray().toBytes()
+        val filler = ByteArray(BUFFER_CAPACITY.toInt() - (HEADER_SIZE + "f".length))
+        val originalValue = ByteArray(64)
+        val replacementValue = byteArrayOf(0x01)
+
+        blobStore.write(fillerKey, filler, false)
+        blobStore.write(movedKey, originalValue, false)
+        blobStore.flushDirtyPages()
+
+        blobStore.delete(fillerKey)
+        blobStore.flushDirtyPages()
+
+        val bin = File(context.noBackupFilesDir, "$fileName.bin")
+        assertEquals(BUFFER_CAPACITY * 2, bin.length())
+
+        blobStore.write(movedKey, replacementValue, true)
+        blobStore.flushDirtyPages()
+
+        assertEquals(BUFFER_CAPACITY, bin.length())
+        assertEquals(0, blobStore.entryMetas.getValue(movedKey).page)
+        assertContentEquals(replacementValue, blobStore.loadPersistedEntries()[movedKey])
+        assertReopenedStore { entries ->
+            assertEquals(1, entries.size)
+            assertContentEquals(replacementValue, entries[movedKey])
+        }
+    }
+
+    @Test
+    fun deleteFromConsecutiveLastPages_shouldReclaimAllEmptyPagesAfterFlush() = runTest {
+        val keys = List(3) { it.toString().toByteArray().toBytes() }
+        keys.forEachIndexed { index, key ->
+            val value = ByteArray(BUFFER_CAPACITY.toInt() - (HEADER_SIZE + index.toString().length))
+            blobStore.write(key, value, false)
+        }
+        blobStore.flushDirtyPages()
+
+        val bin = File(context.noBackupFilesDir, "$fileName.bin")
+        assertEquals(BUFFER_CAPACITY * 3, bin.length())
+
+        blobStore.delete(keys[1], keys[2])
+        blobStore.flushDirtyPages()
+
+        assertEquals(BUFFER_CAPACITY, bin.length())
+        val survivor = ByteArray(BUFFER_CAPACITY.toInt() - (HEADER_SIZE + "0".length))
+        assertContentEquals(survivor, blobStore.loadPersistedEntries()[keys[0]])
+        assertFalse(blobStore.contains(keys[1]))
+        assertFalse(blobStore.contains(keys[2]))
+        assertReopenedStore { entries ->
+            assertEquals(1, entries.size)
+            assertContentEquals(survivor, entries[keys[0]])
+        }
+    }
+
+    /**
+     * Files written before tail reclamation existed can already carry an empty trailing page.
+     * Opening one must reclaim it even though nothing in this session ever emptied a page, so
+     * the reclaim scan cannot be gated on state accumulated since the store was constructed.
+     */
+    @Test
+    fun flush_onFileWithPreexistingEmptyTailPage_shouldReclaim() = runTest {
+        val keyA = "a".toByteArray().toBytes()
+        val keyB = "b".toByteArray().toBytes()
+        val valueA = ByteArray(BUFFER_CAPACITY.toInt() - (HEADER_SIZE + "a".length))
+
+        blobStore.write(keyA, valueA, false)
+        blobStore.write(keyB, byteArrayOf(0x01), false)
+        blobStore.flushDirtyPages()
+        blobStore.delete(keyB, true) // forceNow empties page 1 without leaving a dirty bit
+        blobStore.closeWhenIdle() // closed before flushing, so the file keeps its second page
+
+        val bin = File(context.noBackupFilesDir, "$fileName.bin")
+        assertEquals(BUFFER_CAPACITY * 2, bin.length())
+
+        val reopened = SafeBoxBlobStore.create(context, fileName)
+        try {
+            assertContentEquals(valueA, reopened.loadPersistedEntries()[keyA])
+            reopened.flushDirtyPages()
+
+            assertEquals(BUFFER_CAPACITY, bin.length())
+        } finally {
+            reopened.closeWhenIdle()
+        }
+        assertReopenedStore { entries ->
+            assertEquals(1, entries.size)
+            assertContentEquals(valueA, entries[keyA])
+        }
+    }
+
+    @Test
+    fun flush_withoutPendingChanges_shouldKeepFileIntact() = runTest {
+        val key = "a".toByteArray().toBytes()
+        val value = ByteArray(64)
+        blobStore.write(key, value, false)
+        blobStore.flushDirtyPages()
+
+        val bin = File(context.noBackupFilesDir, "$fileName.bin")
+        val lengthAfterWrite = bin.length()
+
+        blobStore.flushDirtyPages()
+        blobStore.flushDirtyPages()
+
+        assertEquals(lengthAfterWrite, bin.length())
+        assertContentEquals(value, blobStore.loadPersistedEntries()[key])
     }
 
     @Test

--- a/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
@@ -295,7 +295,7 @@ internal class SafeBoxEngine private constructor(
         val currentWriteBarrier = CompletableDeferred<Unit>()
         val previousWriteBarrier = writeBarrier.getAndSet(currentWriteBarrier)
         return runBlocking {
-            try {
+            var committed = try {
                 initialReadCompleted.await()
                 previousWriteBarrier.await()
                 writeMutex.withLock {
@@ -305,13 +305,19 @@ internal class SafeBoxEngine private constructor(
             } catch (e: Exception) {
                 Log.e("SafeBox", "Failed to commit changes.", e)
                 false
-            } finally {
+            }
+            try {
                 blobStore.flushDirtyPages()
+            } catch (e: Exception) {
+                Log.e("SafeBox", "Failed to flush pending changes.", e)
+                committed = false
+            } finally {
                 currentWriteBarrier.complete(Unit)
                 if (recoveryEntries.isNotEmpty() && recoveryScheduled.compareAndSet(false, true)) {
                     scheduleRecoveryEntriesWrite(DEFAULT_BACKOFF_MS)
                 }
             }
+            committed
         }
     }
 
@@ -331,8 +337,13 @@ internal class SafeBoxEngine private constructor(
             } catch (e: Exception) {
                 Log.e("SafeBox", "Failed to commit changes.", e)
             } finally {
-                blobStore.flushDirtyPages()
-                currentWriteBarrier.complete(Unit)
+                try {
+                    blobStore.flushDirtyPages()
+                } catch (e: Exception) {
+                    Log.e("SafeBox", "Failed to flush pending changes.", e)
+                } finally {
+                    currentWriteBarrier.complete(Unit)
+                }
             }
         }.invokeOnCompletion {
             if (recoveryBackoffMs == DEFAULT_BACKOFF_MS && recoveryScheduled.get()) {

--- a/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/storage/SafeBoxBlobStore.kt
@@ -271,29 +271,57 @@ internal class SafeBoxBlobStore private constructor(private val file: File) {
         }
     }
 
+    /**
+     * Forces pending changes to disk and reclaims consecutive empty pages from the file tail.
+     *
+     * Every step is ordered so a failure leaves state the next flush can still make progress on:
+     * - Dirty pages are forced first, including any dirty page about to be discarded. Their bytes
+     *   were already zeroed by [shiftLeft], so should the truncation below be lost to a crash,
+     *   the old-length file reads back with an empty tail instead of resurrecting deleted entries.
+     * - The file is truncated *before* its pages leave [buffers]. Nothing here can establish
+     *   what a throwing `channel.truncate` left on disk; this ordering only avoids the known
+     *   bad case of shrinking the in-memory layout for a truncation that may not have happened.
+     * - [dirtyPagesMask] and [needsChannelForce] are cleared only once the calls they stand for
+     *   return, so an interrupted flush repeats that work instead of dropping the obligation.
+     *
+     * A normal return means the mappings marked dirty were forced, and that a reclaimed length
+     * was truncated and its metadata forced. It is not a general durability barrier: a flush
+     * with nothing outstanding issues no I/O, and page growth from [addNewPage] is not fsynced
+     * on its own.
+     *
+     * Pages dropped here stay mapped until the GC frees them, which is safe only because nothing
+     * reads a page once it leaves [buffers]. Never retain a reference to a dropped buffer.
+     */
     internal suspend fun flushDirtyPages() {
-        if (dirtyPagesMask == 0L) {
-            return
-        }
         writeMutex.withLock {
-            if (needsChannelForce.getAndSet(false)) {
+            if (needsChannelForce.get()) {
                 buffers.forEach { it.force() }
-                channel.force(true)
-                dirtyPagesMask = 0L
-                return@withLock
-            }
-            var mask = dirtyPagesMask
-            if (mask == 0L) {
-                return@withLock
-            }
-            while (mask != 0L) {
-                val page = java.lang.Long.numberOfTrailingZeros(mask)
-                if (page < buffers.size) {
-                    buffers[page].force()
+            } else {
+                var mask = dirtyPagesMask
+                while (mask != 0L) {
+                    val page = mask.countTrailingZeroBits()
+                    if (page < buffers.size) {
+                        buffers[page].force()
+                    }
+                    mask = mask and (mask - 1)
                 }
-                mask = mask and (mask - 1)
             }
             dirtyPagesMask = 0L
+            val retainedPages = retainedPageCount()
+            if (retainedPages < buffers.size) {
+                channel.truncate(retainedPages * BUFFER_CAPACITY)
+                while (buffers.size > retainedPages) {
+                    val page = buffers.lastIndex
+                    buffers.removeAt(page)
+                    nextWritePositions.removeAt(page)
+                    perPageEncryptedKeys.removeAt(page)
+                }
+                needsChannelForce.set(true)
+            }
+            if (needsChannelForce.get()) {
+                channel.force(true)
+                needsChannelForce.set(false)
+            }
         }
     }
 
@@ -344,6 +372,29 @@ internal class SafeBoxBlobStore private constructor(private val file: File) {
         buffers.add(newBuffer)
         nextWritePositions.add(0)
         perPageEncryptedKeys.add(HashSet())
+    }
+
+    /**
+     * Counts the pages the file must keep, trimming consecutive empty tail pages but never
+     * page 0. Pure by design: the caller truncates before acting on the result.
+     *
+     * Reclamation is optional and runs inside a finalization path, so a desynced parallel
+     * collection returns "keep everything" rather than throwing or, worse, truncating away a
+     * page that metadata still claims holds entries.
+     */
+    private fun retainedPageCount(): Int {
+        if (buffers.size != nextWritePositions.size || buffers.size != perPageEncryptedKeys.size) {
+            return buffers.size
+        }
+        var retained = buffers.size
+        while (
+            retained > 1 &&
+            nextWritePositions[retained - 1] == 0 &&
+            perPageEncryptedKeys[retained - 1].isEmpty()
+        ) {
+            retained--
+        }
+        return retained
     }
 
     private fun markDirty(page: Int, forceNow: Boolean) {


### PR DESCRIPTION
### Summary

Reclaimed consecutive empty pages from the blob store tail to reduce unused file growth and mapped memory.

### Implementation Details

Added tail-page reclamation to the flush path while preserving retry state across I/O failures. Updated write barriers so a failed flush cannot block subsequent writes.

Covered deletion and overwrite flows, including legacy empty tails and shrink-regrow behavior.

Closes #165